### PR TITLE
Filter methods without "operationId" from Martian instance.

### DIFF
--- a/core/test/martian/core_test.cljc
+++ b/core/test/martian/core_test.cljc
@@ -53,7 +53,10 @@
                                                                                 :in "body"
                                                                                 :required true
                                                                                 :schema {:type "array"
-                                                                                         :items {:$ref "#/definitions/User"}}}]}}}
+                                                                                         :items {:$ref "#/definitions/User"}}}]}
+                                                           ;; operationId is intentionally missing from the get method
+                                                           :get {}}}
+
    :definitions {:Pet {:type "object"
                        :properties {:id {:type "integer"
                                          :required true}


### PR DESCRIPTION
Martian can now be used when not all methods have an operationId, allowing
a more gradual introduction of Martian.