### PR TITLE
Allow :martian.core/body to be used as the body schema name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ like that provided by [pedestal-api](https://github.com/oliyh/pedestal-api):
   (let [pet-id (-> (martian/response-for m :create-pet {:pet {:name "Doggy McDogFace" :type "Dog" :age 3}})
                    (get-in [:body :id]))]
 
+  ;; :martian.core/body can optionally be used in lieu of explicitly naming the body schema
+  (let [pet-id (-> (martian/response-for m :create-pet {::martian/body {:name "Doggy McDogFace" :type "Dog" :age 3}})
+                   (get-in [:body :id]))]
+
+
     ;; load the pet using the id
     (martian/response-for m :get-pet {:id pet-id})))
 

--- a/core/src/martian/interceptors.cljc
+++ b/core/src/martian/interceptors.cljc
@@ -38,9 +38,13 @@
 (def set-body-params
   {:name ::body-params
    :enter (fn [{:keys [params handler] :as ctx}]
-            (update ctx :request insert-or-merge :body (some-> (schema/coerce-data (:body-schema handler) params)
-                                                               first
-                                                               val)))})
+            (let [body (or
+                         (some->> (:martian.core/body params)
+                                  (schema/coerce-data (-> (:body-schema handler) first val)))
+                         (some-> (schema/coerce-data (:body-schema handler) params)
+                                 first
+                                 val))]
+              (update ctx :request insert-or-merge :body body)))})
 
 (def set-form-params
   {:name ::form-params

--- a/core/test/martian/core_test.cljc
+++ b/core/test/martian/core_test.cljc
@@ -188,7 +188,8 @@
             :url "https://api.org/pets/"
             :body {:id 123 :name "charlie"}}
            (request-for :create-pet {:pet {:id 123 :name "charlie"}})
-           (request-for :create-pet {:pet {:id "123" :name "charlie"}})))
+           (request-for :create-pet {:pet {:id "123" :name "charlie"}})
+           (request-for :create-pet {::martian/body {:id 123 :name "charlie"}})))
 
     (is (= {:method :post
             :url "https://api.org/users/"


### PR DESCRIPTION
If no :martian.core/body parameter fallback to previous behaviour of
matching the schema name.

This change makes it easy to call methods with anonymous body schemas from
compojure-api which don't have deterministic names (body34512 etc).