### PR TITLE
add cljdoc.edn config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
           paths:
             - /usr/local/bin/phantomjs
 
+      # Validate docs/cljdoc.edn
+      - run: curl -fsSL https://raw.githubusercontent.com/cljdoc/cljdoc/master/script/verify-cljdoc-edn | bash -s docs/cljdoc.edn
+
       - run: phantomjs --version
 
       - run: lein test

--- a/docs/cljdoc.edn
+++ b/docs/cljdoc.edn
@@ -1,0 +1,2 @@
+{:cljdoc.doc/tree [["Readme" {:file "README.md"}]
+                   ["Re-frame Integration" {:file "re-frame/README.md"}]]}


### PR DESCRIPTION
Follow up to #59.

Currently a README from one of the talks is pulled in and cljdoc's slug generation isn't yet (https://github.com/cljdoc/cljdoc/issues/120) smart enough to discern the two READMEs. 

The added `docs/cljdoc.edn` file also includes the README of the Re-frame module and adds a CI step to verify that all files referenced in `docs/cljdoc.edn` exist.