### PR TITLE
Extract keywordize-keys on params to interceptors

### DIFF
--- a/core/src/martian/core.cljc
+++ b/core/src/martian/core.cljc
@@ -9,7 +9,8 @@
             [schema.core :as s]))
 
 (def default-interceptors
-  [interceptors/set-method
+  [interceptors/keywordize-params
+   interceptors/set-method
    interceptors/set-url
    interceptors/set-query-params
    interceptors/set-body-params
@@ -63,8 +64,7 @@
   ([martian route-name] (request-for martian route-name {}))
   ([{:keys [handlers interceptors] :as martian} route-name params]
    (when-let [handler (find-handler handlers route-name)]
-     (let [params (keywordize-keys params)
-           ctx (tc/enqueue* {} (-> (or interceptors default-interceptors) vec (conj interceptors/request-only-handler)))]
+     (let [ctx (tc/enqueue* {} (-> (or interceptors default-interceptors) vec (conj interceptors/request-only-handler)))]
        (:request (tc/execute
                   (assoc ctx
                          :url-for (partial url-for martian)
@@ -76,8 +76,7 @@
   ([martian route-name] (response-for martian route-name {}))
   ([{:keys [handlers interceptors] :as martian} route-name params]
    (when-let [handler (find-handler handlers route-name)]
-     (let [params (keywordize-keys params)
-           ctx (tc/enqueue* {} (or interceptors default-interceptors))]
+     (let [ctx (tc/enqueue* {} (or interceptors default-interceptors))]
        (:response (tc/execute
                    (assoc ctx
                           :url-for (partial url-for martian)

--- a/core/src/martian/interceptors.cljc
+++ b/core/src/martian/interceptors.cljc
@@ -1,6 +1,6 @@
 (ns martian.interceptors
   (:require [martian.schema :as schema]
-            [clojure.walk :refer [stringify-keys]]
+            [clojure.walk :refer [keywordize-keys stringify-keys]]
             [clojure.string :as string]
             [tripod.context :as tc]
             [schema.core :as s]
@@ -36,6 +36,10 @@
 
 (defn coerce-data [{:keys [parameter-aliases] :as handler} schema-key params]
   (schema/coerce-data (get handler schema-key) params parameter-aliases))
+
+(def keywordize-params
+  {:name ::keywordize-params
+   :enter (fn [ctx] (update ctx :params keywordize-keys))})
 
 (def set-query-params
   {:name ::query-params


### PR DESCRIPTION
clojure.walk/keywordize-keys recursively clobbers map-like data
structures. This commit pulls out the call to keywordize-keys on the
params map into the `default-interceptors`. It retains the default
behaviour, but allows the user to optionally customize the behaviour.

Fix: #62