### PR TITLE
Handle free form objects

### DIFF
--- a/core/project.clj
+++ b/core/project.clj
@@ -26,7 +26,7 @@
                    :dependencies [[org.clojure/clojure "1.10.1"]
                                   [org.clojure/clojurescript "1.10.520"]
                                   [org.clojure/tools.reader "1.2.2"]
-                                  [cider/piggieback "0.3.6"]
+                                  [cider/piggieback "0.4.1"]
                                   [org.clojure/tools.nrepl "0.2.13"]]
                    :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]}}}
   :aliases {"test" ["do" ["clean"] ["test"] ["doo" "nashorn" "test" "once"]]}

--- a/core/src/martian/core.cljc
+++ b/core/src/martian/core.cljc
@@ -22,7 +22,9 @@
 
 (defn- enrich-handler [handler]
   (-> handler
-      (assoc :parameter-aliases (let [ks (schema/parameter-keys (map handler parameter-schemas))]
+      (assoc :parameter-aliases (let [ks (->> (map handler parameter-schemas)
+                                              schema/parameter-keys
+                                              (remove #(= % s/Any)))]
                                   (zipmap (map ->kebab-case-keyword ks) ks)))))
 
 (defn- concise->handlers [concise-handlers global-produces global-consumes]

--- a/core/src/martian/schema.cljc
+++ b/core/src/martian/schema.cljc
@@ -131,7 +131,7 @@
 
               (= "object" type)
               (cond-> (schemas-for-parameters definitions (map (fn [[name p]] (assoc p :name name)) properties))
-                (or additionalProperties (= additionalProperties {})) (assoc (s/optional-key s/Any) s/Any))
+                additionalProperties (assoc (s/optional-key s/Any) s/Any))
 
               :else
               (schema-type definitions param))

--- a/core/src/martian/schema.cljc
+++ b/core/src/martian/schema.cljc
@@ -110,7 +110,7 @@
 
 (defn make-schema
   "Takes a swagger parameter and returns a schema"
-  [definitions {:keys [name required type enum schema properties $ref items] :as param}]
+  [definitions {:keys [name required type enum schema properties $ref items additionalProperties] :as param}]
 
   (cond
     $ref
@@ -130,7 +130,8 @@
               [(schema-type definitions (assoc (:items schema) :required true))]
 
               (= "object" type)
-              (schemas-for-parameters definitions (map (fn [[name p]] (assoc p :name name)) properties))
+              (cond-> (schemas-for-parameters definitions (map (fn [[name p]] (assoc p :name name)) properties))
+                (or additionalProperties (= additionalProperties {})) (assoc (s/optional-key s/Any) s/Any))
 
               :else
               (schema-type definitions param))

--- a/core/test/martian/schema_test.cljc
+++ b/core/test/martian/schema_test.cljc
@@ -5,6 +5,26 @@
             #?(:clj [clojure.test :refer :all]
                :cljs [cljs.test :refer-macros [deftest testing is run-tests]])))
 
+(deftest free-form-object-test
+  (let [schema (schema/make-schema {:Body55523       {:type                 "object"
+                                                      :properties           {:age    {:$ref "#/definitions/Body55523Age"}
+                                                                             :name   {:$ref "#/definitions/Body55523Name"}
+                                                                             :colour {:$ref "#/definitions/Body55523Colour"}}
+                                                      :additionalProperties false
+                                                      :required             ["name"]}
+                                    :Body55523Age    {:type "object" :additionalProperties {}}
+                                    :Body55523Name   {:type "object" :additionalProperties {}}
+                                    :Body55523Colour {:type "object" :additionalProperties {}}}
+                                   {:in          "body"
+                                    :name        "Body55523"
+                                    :description ""
+                                    :required    true
+                                    :schema      {:$ref "#/definitions/Body55523"}})]
+    (is (= {(s/optional-key :name)   (s/maybe {(s/optional-key s/Any) s/Any})
+            (s/optional-key :age)    (s/maybe {(s/optional-key s/Any) s/Any})
+            (s/optional-key :colour) (s/maybe {(s/optional-key s/Any) s/Any})}
+           schema))))
+
 (deftest enum-test
   (is (= (s/enum "desc" "asc")
          (schema/make-schema {} {:name "sort"
@@ -112,6 +132,25 @@
               :in "path"
               :required true
               :type "integer"}]))))
+  (testing "object with additional properties"
+    (is (= {:Pet {(s/optional-key s/Any) s/Any}}
+           (schema/schemas-for-parameters
+            {:Pet {:type       "object"
+                   :additionalProperties true
+                   :properties {}}}
+            [{:name "Pet"
+              :in "path"
+              :required true
+              :schema {:$ref "#/definitions/Pet"}}]))))
+  (testing "object with empty properties"
+    (is (= {:Pet {}}
+           (schema/schemas-for-parameters
+            {:Pet {:type       "object"
+                   :properties {}}}
+            [{:name "Pet"
+              :in "path"
+              :required true
+              :schema {:$ref "#/definitions/Pet"}}]))))
 
   (testing "body params"
     (is (= {:Pet {:CamelBodyKey s/Int}}

--- a/core/test/martian/schema_test.cljc
+++ b/core/test/martian/schema_test.cljc
@@ -133,25 +133,26 @@
               :required true
               :type "integer"}]))))
   (testing "object with additional properties"
-    (is (= {:Pet {(s/optional-key s/Any) s/Any}}
+    (is (= {:Pet {:CamelBodyKey          s/Int
+                  (s/optional-key s/Any) s/Any}}
            (schema/schemas-for-parameters
-            {:Pet {:type       "object"
+            {:Pet {:type                 "object"
                    :additionalProperties true
-                   :properties {}}}
-            [{:name "Pet"
-              :in "path"
+                   :properties           {:CamelBodyKey {:type     "integer"
+                                                         :required true}}}}
+            [{:name     "Pet"
+              :in       "path"
               :required true
-              :schema {:$ref "#/definitions/Pet"}}]))))
+              :schema   {:$ref "#/definitions/Pet"}}]))))
   (testing "object with empty properties"
     (is (= {:Pet {}}
            (schema/schemas-for-parameters
             {:Pet {:type       "object"
                    :properties {}}}
-            [{:name "Pet"
-              :in "path"
+            [{:name     "Pet"
+              :in       "path"
               :required true
-              :schema {:$ref "#/definitions/Pet"}}]))))
-
+              :schema   {:$ref "#/definitions/Pet"}}]))))
   (testing "body params"
     (is (= {:Pet {:CamelBodyKey s/Int}}
 


### PR DESCRIPTION
At the moment if you have a swagger property like this :

```clojure
{:Pet {:type  "object" :properties {}}}
```

The Plumatic schema that you get is:
```clojure
{:Pet {}}
```
This only allows an empty map as a posible value, which is quite restrictive and probably not very useful.

So, this PR changes the existing code so that if you have no explicit properties, it will produce the following to allow any value:

```clojure
{:Pet s/Any}
```

Happy to hear your thoughts on the approach and implementation. Relevant swagger docs for free form objects https://swagger.io/docs/specification/data-models/data-types#free-form.

Oliver
