### PR TITLE
Fixes parameter-keys for open maps

### DIFF
--- a/core/src/martian/schema.cljc
+++ b/core/src/martian/schema.cljc
@@ -55,13 +55,18 @@
       :else
       ((sc/coercer! schema coercion-matchers) data))))
 
+(defn- extract-keys-from-map-schema [schema]
+  (->> (keys schema)
+       (filter s/specific-key?)
+       (map s/explicit-schema-key)))
+
 (defn parameter-keys [schemas]
   (mapcat
    (fn [schema]
      (when-let [s (from-maybe schema)]
        (cond
          (and (map? s) (not (record? s)))
-         (concat (map s/explicit-schema-key (keys s)) (parameter-keys (vals s)))
+         (concat (extract-keys-from-map-schema s) (parameter-keys (vals s)))
 
          (coll? s)
          (parameter-keys s)

--- a/core/test/martian/schema_test.cljc
+++ b/core/test/martian/schema_test.cljc
@@ -209,6 +209,10 @@
   (is (= [:foo]
          (schema/parameter-keys [{:foo s/Int}])))
 
+  (is (= [:foo]
+         (schema/parameter-keys [{:foo s/Int
+                                  s/Any s/Any}])))
+
   (is (= [:foo :bar]
          (schema/parameter-keys [{:foo s/Int}
                                  {:bar s/Str}])))


### PR DESCRIPTION
https://github.com/oliyh/martian/pull/76 introduced a bug on `enrich-handler`
More specifically on `parameter-keys`, since it is calling `s/explicit-schema-key` on `s/Any`
and giving this error
```
Bad explicit key: schema.core.AnythingSchema@3c6f0b88
```

Making the client unusable (for this swagger.json)