### PR TITLE
Introduced clj-http-lite

### DIFF
--- a/clj-http-lite/.gitignore
+++ b/clj-http-lite/.gitignore
@@ -1,0 +1,14 @@
+pom.xml
+pom.xml.asc
+*jar
+/lib/
+/classes/
+/target/
+/checkouts/
+.lein-deps-sum
+.lein-repl-history
+.lein-plugins/
+.lein-failures
+.nrepl-port
+.cljs_rhino_repl/
+/out/

--- a/clj-http-lite/project.clj
+++ b/clj-http-lite/project.clj
@@ -1,0 +1,17 @@
+(defproject martian-clj-http-lite "0.1.12-SNAPSHOT"
+  :description "clj-http-lite implementation for martian"
+  :url "https://github.com/oliyh/martian"
+  :license {:name "The MIT License"
+            :url "http://opensource.org/licenses/MIT"}
+  :plugins [[lein-modules "0.3.11"]]
+  :dependencies [[martian :version]
+                 [org.martinklepsch/clj-http-lite "0.4.3"]
+                 [cheshire "5.9.0"]]
+  :profiles {:provided {:dependencies [[org.clojure/clojure "1.10.1"]]}
+             :dev {:source-paths ["../test-common"]
+                   :exclusions [[org.clojure/tools.reader]]
+                   :dependencies [[org.clojure/clojure "1.10.1"]
+                                  [org.clojure/tools.reader "1.2.2"]
+                                  [pedestal-api "0.3.4"]
+                                  [io.pedestal/pedestal.service "0.5.3"]
+                                  [io.pedestal/pedestal.jetty "0.5.3"]]}})

--- a/clj-http-lite/src/martian/clj_http_lite.clj
+++ b/clj-http-lite/src/martian/clj_http_lite.clj
@@ -1,0 +1,31 @@
+(ns martian.clj-http-lite
+  (:require [clj-http.lite.client :as http]
+            [cheshire.core :as json]
+            [martian.core :as martian]
+            [martian.interceptors :as interceptors]))
+
+(defn- prepare-response-headers [headers]
+  (reduce (fn [m [k v]] (assoc m (keyword k) v)) {} headers))
+
+(def perform-request
+  {:name ::perform-request
+   :leave (fn [{:keys [request] :as ctx}]
+            (assoc ctx :response (-> (http/request request)
+                                     ;; convert keys to keywords
+                                     (update-in [:headers] prepare-response-headers))))})
+
+(def default-interceptors
+  (concat martian/default-interceptors [interceptors/default-encode-body interceptors/default-coerce-response perform-request]))
+
+(defn bootstrap [api-root concise-handlers & [opts]]
+  (martian/bootstrap api-root concise-handlers (merge {:interceptors default-interceptors} opts)))
+
+(defn bootstrap-swagger [url & [{:keys [interceptors] :as params}]]
+  ;; clj-http-lite does not support {:as :json} body conversion (yet) so we do it right here
+  (let [swagger-definition (-> (http/get url) :body (json/parse-string keyword))
+        {:keys [scheme server-name server-port]} (http/parse-url url)
+        base-url (format "%s://%s%s%s" (name scheme) server-name (if server-port (str ":" server-port) "") (get swagger-definition :basePath ""))]
+    (martian/bootstrap-swagger
+     base-url
+     swagger-definition
+     {:interceptors (or interceptors default-interceptors)})))

--- a/clj-http-lite/test/martian/clj_http_lite_test.clj
+++ b/clj-http-lite/test/martian/clj_http_lite_test.clj
@@ -1,0 +1,39 @@
+(ns martian.clj-http-lite-test
+  (:require [martian.clj-http-lite :as martian-http]
+            [martian.core :as martian]
+            [martian.encoders :as encoders]
+            [tripod.context :as tc]
+            [martian.interceptors :as i]
+            [martian.server-stub :refer [with-server swagger-url]]
+            [martian.test-utils :refer [input-stream->byte-array]]
+            [clojure.test :refer :all]))
+
+(use-fixtures :once with-server)
+
+(deftest http-test
+
+  (let [m (martian-http/bootstrap-swagger swagger-url)]
+    (testing "default encoders"
+      (is (= {:method :post
+              :url "http://localhost:8888/pets/"
+              :body {:name "Doggy McDogFace", :type "Dog", :age 3}
+              :headers {"Accept" "application/transit+msgpack"
+                        "Content-Type" "application/transit+msgpack"}
+              :as :byte-array}
+             (-> (martian/request-for m :create-pet {:pet {:name "Doggy McDogFace"
+                                                           :type "Dog"
+                                                           :age 3}})
+                 (update :body #(encoders/transit-decode (input-stream->byte-array %) :msgpack))))))
+
+    (let [response (martian/response-for m :create-pet {:pet {:name "Doggy McDogFace"
+                                                              :type "Dog"
+                                                              :age 3}})]
+      (is (= {:status 201
+              :body {:id 123}}
+             (select-keys response [:status :body]))))
+
+    (let [response (martian/response-for m :get-pet {:id 123})]
+      (is (= {:name "Doggy McDogFace"
+              :type "Dog"
+              :age 3}
+             (:body response))))))


### PR DESCRIPTION
Hi,

This `clj-http-lite` based client is almost a complete copy of the `clj-http` client at least passes all tests and also works with [k8s-api](https://github.com/deas/k8s-api) (even with `watch`). Will be massaging pluggability in `k8s-api` a bit more and provide a PR over there soon. Still thinking about the `watch` implementation a bit, but I don't consider that related to `clj-http-lite` in `martian` scope.