### PR TITLE
Remove implicit httpkit dependency from martian test

### DIFF
--- a/cljs-http/src/martian/cljs_http.cljs
+++ b/cljs-http/src/martian/cljs_http.cljs
@@ -7,8 +7,8 @@
             [clojure.string :as str])
   (:require-macros [cljs.core.async.macros :refer [go]]))
 
-(defn- go-async [ctx]
-  (-> ctx tc/terminate (dissoc ::tc/stack)))
+(def ^:private go-async
+  i/remove-stack)
 
 (def perform-request
   {:name ::perform-request

--- a/core/src/martian/interceptors.cljc
+++ b/core/src/martian/interceptors.cljc
@@ -8,10 +8,12 @@
             [martian.encoding :as encoding]
             [martian.encoders :as encoders]))
 
+(defn remove-stack [ctx]
+  (-> ctx tc/terminate (dissoc ::tc/stack)))
+
 (def request-only-handler
   {:name ::request-only-handler
-   :leave (fn [ctx]
-            (-> ctx tc/terminate (dissoc ::tc/stack)))})
+   :leave remove-stack})
 
 (defn- create-only [m k v]
   (if (get m k)

--- a/httpkit/src/martian/httpkit.clj
+++ b/httpkit/src/martian/httpkit.clj
@@ -15,8 +15,7 @@
      :server-port (let [port (.getPort url-parsed)]
                     (when (pos? port) port))}))
 
-(defn go-async [ctx]
-  (-> ctx tc/terminate (dissoc ::tc/stack)))
+(def go-async interceptors/remove-stack)
 
 (def perform-request
   {:name ::perform-request

--- a/test/src/martian/test.cljc
+++ b/test/src/martian/test.cljc
@@ -5,8 +5,7 @@
             [clojure.test.check.generators :as tcg]
             [schema.core :as s]
             [tripod.context :as tc]
-            #?(:clj [martian.httpkit :refer [go-async]]
-               :cljs [cljs.core.async :as a])))
+            #?(:cljs [cljs.core.async :as a])))
 
 (defn- status-range [from to]
   (fn [{:keys [status]}]
@@ -61,7 +60,7 @@
      {:name ::httpkit-responder
       :leave (fn [ctx]
                (-> ctx
-                   go-async
+                   interceptors/remove-stack
                    (assoc :response (future (:response (tc/execute ctx))))))}))
 
 #?(:clj


### PR DESCRIPTION
Add intercetptors `remove-stack` which is equivalent to httpkit `go-async`.