### PR TITLE
Add openapi->handlers functionality

### DIFF
--- a/core/src/martian/openapi.cljc
+++ b/core/src/martian/openapi.cljc
@@ -1,0 +1,116 @@
+(ns martian.openapi
+  (:require [camel-snake-kebab.core :refer [->kebab-case-keyword]]
+            [clojure.string :as string]
+            [schema.core :as s]))
+
+(defn- tokenise-path [url-pattern]
+  (for [part (re-seq #"[^{]+|\{[^}]+?\}" url-pattern)]
+    (if-let [param (re-matches #"^\{(.*)\}$" part)]
+      (keyword (second param))
+      part)))
+
+(defn- lookup-ref [components reference]
+  (if (string/starts-with? reference "#/components/")
+    (or (get-in components (drop 2 (string/split reference #"/")))
+        (throw (ex-info "Cannot find reference"
+                        {:reference reference})))
+    (throw (ex-info "References start with something other than #/components/ aren't supported yet. :("
+                    {:reference reference}))))
+
+(def ^:private URI
+  #?(:clj java.net.URI
+     :cljs goog.Uri))
+
+(defn- openapi->schema
+  ([schema components]
+   (openapi->schema schema components #{}))
+  ([schema components seen-set]
+   (if-let [reference (get schema "$ref")]
+     (if (contains? seen-set reference)
+       s/Any ; If we've already seen this, then we're in a loop. Rather than
+             ; trying to solve for the fixpoint, just return Any.
+       (recur (lookup-ref components reference)
+              components
+              (conj seen-set reference)))
+     (let [wrap (if (get schema "nullable") s/maybe identity)]
+       (wrap
+        (condp = (get schema "type")
+          "string"  (if-let [enum (get schema "enum")]
+                      (apply s/enum enum)
+                      (condp = (get schema "format")
+                        "uuid" s/Uuid
+                        "uri" URI
+                        s/Str))
+          "integer" s/Int
+          "number"  s/Num
+          "boolean" s/Bool
+          "array"   [(openapi->schema (get schema "items") components seen-set)]
+          "object"  (let [required? (set (get schema "required"))]
+                      (into {}
+                            (map (fn [[k v]]
+                                   {(if (required? k)
+                                      (keyword k)
+                                      (s/optional-key (keyword k)))
+                                    (openapi->schema v components seen-set)}))
+                            (get schema "properties")))
+          (throw (ex-info "Cannot convert OpenAPI type to schema" {:definition schema}))))))))
+
+(defn- get-matching-schema [object content-types]
+  (if-let [content-type (first (filter #(get-in object ["content" % "schema"]) content-types))]
+    [(get-in object ["content" content-type "schema"])
+     content-type]
+    (when (seq (get object "content"))
+      (throw (ex-info "No matching content-type available"
+                      {:allowed-content-types  content-types
+                       :response-content-types (keys (get object "content"))})))))
+
+(defn- process-body [body components content-types]
+  (when-let [[json-schema content-type] (get-matching-schema body content-types)]
+    (let [required (get body "required")]
+      {:schema       {(if required :body (s/optional-key :body))
+                      (openapi->schema json-schema components)}
+       :content-type content-type})))
+
+(defn- process-parameters [parameters components]
+  (into {}
+        (map (fn [param]
+               {(if (get param "required")
+                  (keyword (get param "name"))
+                  (s/optional-key (keyword (get param "name"))))
+                (openapi->schema (get param "schema") components)}))
+        parameters))
+
+(defn- process-responses [responses components content-types]
+  (for [[code value] responses
+        :let         [[json-schema content-type] (get-matching-schema value content-types)]]
+    {:status       (if (= code "default")
+                     s/Any
+                     (s/eq (Long/parseLong code)))
+     :body         (and json-schema (openapi->schema json-schema components))
+     :content-type content-type}))
+
+(defn openapi->handlers [swagger-json content-types]
+  (let [components (get swagger-json "components")]
+    (for [[url methods] (get swagger-json "paths")
+          [method definition] methods
+          ;; We only care about things which have a defined operationId, and
+          ;; which aren't the associated OPTIONS call.
+          :when (and (get definition "operationId")
+                     (not= method "options"))
+          :let [parameters (group-by #(get % "in") (get definition "parameters"))
+                body       (process-body (get definition "requestBody") components content-types)
+                responses  (process-responses (get definition "responses") components content-types)]]
+      {:path-parts         (vec (tokenise-path url))
+       :method             (keyword method)
+       :path-schema        (process-parameters (get parameters "path") components)
+       :query-schema       (process-parameters (get parameters "query") components)
+       :body-schema        (:schema body)
+       :form-schema        (process-parameters (get parameters "form") components)
+       :headers-schema     (process-parameters (get parameters "header") components)
+       :response-schemas   (vec (keep #(dissoc % :content-type) responses))
+       :produces           (vec (keep :content-type responses))
+       :consumes           [(:content-type body)]
+       :summary            (get definition "summary")
+       :description        (get definition "description")
+       :openapi-definition definition
+       :route-name         (->kebab-case-keyword (get definition "operationId"))})))

--- a/core/test-resources/openapi.json
+++ b/core/test-resources/openapi.json
@@ -1,0 +1,1094 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "Swagger Petstore - OpenAPI 3.0",
+        "description": "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about\nSwagger at [http://swagger.io](http://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!\nYou can now help us improve the API whether it's by making changes to the definition itself or to the code.\nThat way, with time, we can improve the API in general, and expose some of the new features in OAS3.\n\nSome useful links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)",
+        "termsOfService": "http://swagger.io/terms/",
+        "contact": {
+            "email": "apiteam@swagger.io"
+        },
+        "license": {
+            "name": "Apache 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+        },
+        "version": "1.0.5"
+    },
+    "externalDocs": {
+        "description": "Find out more about Swagger",
+        "url": "http://swagger.io"
+    },
+    "servers": [{
+        "url": "/api/v3"
+    }],
+    "tags": [{
+        "name": "pet",
+        "description": "Everything about your Pets",
+        "externalDocs": {
+            "description": "Find out more",
+            "url": "http://swagger.io"
+        }
+    }, {
+        "name": "store",
+        "description": "Operations about user"
+    }, {
+        "name": "user",
+        "description": "Access to Petstore orders",
+        "externalDocs": {
+            "description": "Find out more about our store",
+            "url": "http://swagger.io"
+        }
+    }],
+    "paths": {
+        "/pet": {
+            "put": {
+                "tags": ["pet"],
+                "summary": "Update an existing pet",
+                "description": "Update an existing pet by Id",
+                "operationId": "updatePet",
+                "requestBody": {
+                    "description": "Update an existent pet in the store",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Pet"
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Pet"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Pet"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Pet"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Pet"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Pet not found"
+                    },
+                    "405": {
+                        "description": "Validation exception"
+                    }
+                },
+                "security": [{
+                    "petstore_auth": ["write:pets", "read:pets"]
+                }]
+            },
+            "post": {
+                "tags": ["pet"],
+                "summary": "Add a new pet to the store",
+                "description": "Add a new pet to the store",
+                "operationId": "addPet",
+                "requestBody": {
+                    "description": "Create a new pet in the store",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Pet"
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Pet"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Pet"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Pet"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Pet"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "description": "Invalid input"
+                    }
+                },
+                "security": [{
+                    "petstore_auth": ["write:pets", "read:pets"]
+                }]
+            }
+        },
+        "/pet/findByStatus": {
+            "get": {
+                "tags": ["pet"],
+                "summary": "Finds Pets by status",
+                "description": "Multiple status values can be provided with comma separated strings",
+                "operationId": "findPetsByStatus",
+                "parameters": [{
+                    "name": "status",
+                    "in": "query",
+                    "description": "Status values that need to be considered for filter",
+                    "required": false,
+                    "explode": true,
+                    "schema": {
+                        "type": "string",
+                        "default": "available",
+                        "enum": ["available", "pending", "sold"]
+                    }
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Pet"
+                                    }
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Pet"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid status value"
+                    }
+                },
+                "security": [{
+                    "petstore_auth": ["write:pets", "read:pets"]
+                }]
+            }
+        },
+        "/pet/findByTags": {
+            "get": {
+                "tags": ["pet"],
+                "summary": "Finds Pets by tags",
+                "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+                "operationId": "findPetsByTags",
+                "parameters": [{
+                    "name": "tags",
+                    "in": "query",
+                    "description": "Tags to filter by",
+                    "required": false,
+                    "explode": true,
+                    "schema": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Pet"
+                                    }
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Pet"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid tag value"
+                    }
+                },
+                "security": [{
+                    "petstore_auth": ["write:pets", "read:pets"]
+                }]
+            }
+        },
+        "/pet/{petId}": {
+            "get": {
+                "tags": ["pet"],
+                "summary": "Find pet by ID",
+                "description": "Returns a single pet",
+                "operationId": "getPetById",
+                "parameters": [{
+                    "name": "petId",
+                    "in": "path",
+                    "description": "ID of pet to return",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Pet"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Pet"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Pet not found"
+                    }
+                },
+                "security": [{
+                    "api_key": []
+                }, {
+                    "petstore_auth": ["write:pets", "read:pets"]
+                }]
+            },
+            "post": {
+                "tags": ["pet"],
+                "summary": "Updates a pet in the store with form data",
+                "description": "",
+                "operationId": "updatePetWithForm",
+                "parameters": [{
+                    "name": "petId",
+                    "in": "path",
+                    "description": "ID of pet that needs to be updated",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                }, {
+                    "name": "name",
+                    "in": "query",
+                    "description": "Name of pet that needs to be updated",
+                    "schema": {
+                        "type": "string"
+                    }
+                }, {
+                    "name": "status",
+                    "in": "query",
+                    "description": "Status of pet that needs to be updated",
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "405": {
+                        "description": "Invalid input"
+                    }
+                },
+                "security": [{
+                    "petstore_auth": ["write:pets", "read:pets"]
+                }]
+            },
+            "delete": {
+                "tags": ["pet"],
+                "summary": "Deletes a pet",
+                "description": "",
+                "operationId": "deletePet",
+                "parameters": [{
+                    "name": "api_key",
+                    "in": "header",
+                    "description": "",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }, {
+                    "name": "petId",
+                    "in": "path",
+                    "description": "Pet id to delete",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                }],
+                "responses": {
+                    "400": {
+                        "description": "Invalid pet value"
+                    }
+                },
+                "security": [{
+                    "petstore_auth": ["write:pets", "read:pets"]
+                }]
+            }
+        },
+        "/pet/{petId}/uploadImage": {
+            "post": {
+                "tags": ["pet"],
+                "summary": "uploads an image",
+                "description": "",
+                "operationId": "uploadFile",
+                "parameters": [{
+                    "name": "petId",
+                    "in": "path",
+                    "description": "ID of pet to update",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                }, {
+                    "name": "additionalMetadata",
+                    "in": "query",
+                    "description": "Additional Metadata",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "requestBody": {
+                    "content": {
+                        "application/octet-stream": {
+                            "schema": {
+                                "type": "string",
+                                "format": "binary"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [{
+                    "petstore_auth": ["write:pets", "read:pets"]
+                }]
+            }
+        },
+        "/store/inventory": {
+            "get": {
+                "tags": ["store"],
+                "summary": "Returns pet inventories by status",
+                "description": "Returns a map of status codes to quantities",
+                "operationId": "getInventory",
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "integer",
+                                        "format": "int32"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [{
+                    "api_key": []
+                }]
+            }
+        },
+        "/store/order": {
+            "post": {
+                "tags": ["store"],
+                "summary": "Place an order for a pet",
+                "description": "Place a new order in the store",
+                "operationId": "placeOrder",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Order"
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Order"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Order"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Order"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "description": "Invalid input"
+                    }
+                }
+            }
+        },
+        "/store/order/{orderId}": {
+            "get": {
+                "tags": ["store"],
+                "summary": "Find purchase order by ID",
+                "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions",
+                "operationId": "getOrderById",
+                "parameters": [{
+                    "name": "orderId",
+                    "in": "path",
+                    "description": "ID of order that needs to be fetched",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Order"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Order"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Order not found"
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["store"],
+                "summary": "Delete purchase order by ID",
+                "description": "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors",
+                "operationId": "deleteOrder",
+                "parameters": [{
+                    "name": "orderId",
+                    "in": "path",
+                    "description": "ID of the order that needs to be deleted",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                }],
+                "responses": {
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Order not found"
+                    }
+                }
+            }
+        },
+        "/user": {
+            "post": {
+                "tags": ["user"],
+                "summary": "Create user",
+                "description": "This can only be done by the logged in user.",
+                "operationId": "createUser",
+                "requestBody": {
+                    "description": "Created user object",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/User"
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "$ref": "#/components/schemas/User"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/User"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "default": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            },
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/user/createWithList": {
+            "post": {
+                "tags": ["user"],
+                "summary": "Creates list of users with given input array",
+                "description": "Creates list of users with given input array",
+                "operationId": "createUsersWithListInput",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "successful operation"
+                    }
+                }
+            }
+        },
+        "/user/login": {
+            "get": {
+                "tags": ["user"],
+                "summary": "Logs user into the system",
+                "description": "",
+                "operationId": "loginUser",
+                "parameters": [{
+                    "name": "username",
+                    "in": "query",
+                    "description": "The user name for login",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }, {
+                    "name": "password",
+                    "in": "query",
+                    "description": "The password for login in clear text",
+                    "required": false,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "headers": {
+                            "X-Rate-Limit": {
+                                "description": "calls per hour allowed by the user",
+                                "schema": {
+                                    "type": "integer",
+                                    "format": "int32"
+                                }
+                            },
+                            "X-Expires-After": {
+                                "description": "date in UTC when toekn expires",
+                                "schema": {
+                                    "type": "string",
+                                    "format": "date-time"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid username/password supplied"
+                    }
+                }
+            }
+        },
+        "/user/logout": {
+            "get": {
+                "tags": ["user"],
+                "summary": "Logs out current logged in user session",
+                "description": "",
+                "operationId": "logoutUser",
+                "parameters": [],
+                "responses": {
+                    "default": {
+                        "description": "successful operation"
+                    }
+                }
+            }
+        },
+        "/user/{username}": {
+            "get": {
+                "tags": ["user"],
+                "summary": "Get user by user name",
+                "description": "",
+                "operationId": "getUserByName",
+                "parameters": [{
+                    "name": "username",
+                    "in": "path",
+                    "description": "The name that needs to be fetched. Use user1 for testing. ",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/xml": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid username supplied"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    }
+                }
+            },
+            "put": {
+                "tags": ["user"],
+                "summary": "Update user",
+                "description": "This can only be done by the logged in user.",
+                "operationId": "updateUser",
+                "parameters": [{
+                    "name": "username",
+                    "in": "path",
+                    "description": "name that need to be deleted",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "requestBody": {
+                    "description": "Update an existent user in the store",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/User"
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "$ref": "#/components/schemas/User"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/User"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "default": {
+                        "description": "successful operation"
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["user"],
+                "summary": "Delete user",
+                "description": "This can only be done by the logged in user.",
+                "operationId": "deleteUser",
+                "parameters": [{
+                    "name": "username",
+                    "in": "path",
+                    "description": "The name that needs to be deleted",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }],
+                "responses": {
+                    "400": {
+                        "description": "Invalid username supplied"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Order": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "example": 10
+                    },
+                    "petId": {
+                        "type": "integer",
+                        "format": "int64",
+                        "example": 198772
+                    },
+                    "quantity": {
+                        "type": "integer",
+                        "format": "int32",
+                        "example": 7
+                    },
+                    "shipDate": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "Order Status",
+                        "example": "approved",
+                        "enum": ["placed", "approved", "delivered"]
+                    },
+                    "complete": {
+                        "type": "boolean"
+                    }
+                },
+                "xml": {
+                    "name": "order"
+                }
+            },
+            "Customer": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "example": 100000
+                    },
+                    "username": {
+                        "type": "string",
+                        "example": "fehguy"
+                    },
+                    "address": {
+                        "type": "array",
+                        "xml": {
+                            "name": "addresses",
+                            "wrapped": true
+                        },
+                        "items": {
+                            "$ref": "#/components/schemas/Address"
+                        }
+                    }
+                },
+                "xml": {
+                    "name": "customer"
+                }
+            },
+            "Address": {
+                "type": "object",
+                "properties": {
+                    "street": {
+                        "type": "string",
+                        "example": "437 Lytton"
+                    },
+                    "city": {
+                        "type": "string",
+                        "example": "Palo Alto"
+                    },
+                    "state": {
+                        "type": "string",
+                        "example": "CA"
+                    },
+                    "zip": {
+                        "type": "string",
+                        "example": "94301"
+                    }
+                },
+                "xml": {
+                    "name": "address"
+                }
+            },
+            "Category": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "example": 1
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Dogs"
+                    }
+                },
+                "xml": {
+                    "name": "category"
+                }
+            },
+            "User": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "example": 10
+                    },
+                    "username": {
+                        "type": "string",
+                        "example": "theUser"
+                    },
+                    "firstName": {
+                        "type": "string",
+                        "example": "John"
+                    },
+                    "lastName": {
+                        "type": "string",
+                        "example": "James"
+                    },
+                    "email": {
+                        "type": "string",
+                        "example": "john@email.com"
+                    },
+                    "password": {
+                        "type": "string",
+                        "example": "12345"
+                    },
+                    "phone": {
+                        "type": "string",
+                        "example": "12345"
+                    },
+                    "userStatus": {
+                        "type": "integer",
+                        "description": "User Status",
+                        "format": "int32",
+                        "example": 1
+                    }
+                },
+                "xml": {
+                    "name": "user"
+                }
+            },
+            "Tag": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "xml": {
+                    "name": "tag"
+                }
+            },
+            "Pet": {
+                "required": ["name", "photoUrls"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64",
+                        "example": 10
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "doggie"
+                    },
+                    "category": {
+                        "$ref": "#/components/schemas/Category"
+                    },
+                    "photoUrls": {
+                        "type": "array",
+                        "xml": {
+                            "wrapped": true
+                        },
+                        "items": {
+                            "type": "string",
+                            "xml": {
+                                "name": "photoUrl"
+                            }
+                        }
+                    },
+                    "tags": {
+                        "type": "array",
+                        "xml": {
+                            "wrapped": true
+                        },
+                        "items": {
+                            "$ref": "#/components/schemas/Tag"
+                        }
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "pet status in the store",
+                        "enum": ["available", "pending", "sold"]
+                    }
+                },
+                "xml": {
+                    "name": "pet"
+                }
+            },
+            "ApiResponse": {
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string"
+                    }
+                },
+                "xml": {
+                    "name": "##default"
+                }
+            }
+        },
+        "requestBodies": {
+            "Pet": {
+                "description": "Pet object that needs to be added to the store",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Pet"
+                        }
+                    },
+                    "application/xml": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Pet"
+                        }
+                    }
+                }
+            },
+            "UserArray": {
+                "description": "List of user object",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/User"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "securitySchemes": {
+            "petstore_auth": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://petstore3.swagger.io/oauth/authorize",
+                        "scopes": {
+                            "write:pets": "modify pets in your account",
+                            "read:pets": "read your pets"
+                        }
+                    }
+                }
+            },
+            "api_key": {
+                "type": "apiKey",
+                "name": "api_key",
+                "in": "header"
+            }
+        }
+    }
+}

--- a/core/test/martian/openapi_test.cljc
+++ b/core/test/martian/openapi_test.cljc
@@ -1,0 +1,48 @@
+(ns martian.openapi-test
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is]]
+            [cheshire.core :refer [parse-string]]
+            [schema.core :as s]
+            [martian.openapi :refer [openapi->handlers]]))
+
+(deftest openapi-sanity-check
+  (is (= (-> (parse-string (slurp (io/resource "openapi.json")))
+             (openapi->handlers ["application/json" "application/octet-stream"])
+             (->> (filter #(= (:route-name %) :update-pet)))
+             first
+             (dissoc :openapi-definition))
+         {:summary        "Update an existing pet"
+          :description    "Update an existing pet by Id"
+          :method         :put
+          :produces       ["application/json"]
+          :path-schema    {}
+          :query-schema   {}
+          :form-schema    {}
+          :path-parts     ["/pet"]
+          :headers-schema {}
+          :consumes       ["application/json"]
+          :body-schema
+          {:body
+           {(s/optional-key :id)       s/Int
+            :name                      s/Str
+            (s/optional-key :category) {(s/optional-key :id)   s/Int
+                                        (s/optional-key :name) s/Str}
+            :photoUrls                 [s/Str]
+            (s/optional-key :tags)     [{(s/optional-key :id)   s/Int
+                                         (s/optional-key :name) s/Str}]
+            (s/optional-key :status)   (s/enum "sold" "pending" "available")}}
+          :route-name     :update-pet
+          :response-schemas
+          [{:status (s/eq 200)
+            :body
+            {(s/optional-key :id)       s/Int
+             :name                      s/Str
+             (s/optional-key :category) {(s/optional-key :id)   s/Int
+                                         (s/optional-key :name) s/Str}
+             :photoUrls                 [s/Str]
+             (s/optional-key :tags)     [{(s/optional-key :id)   s/Int
+                                          (s/optional-key :name) s/Str}]
+             (s/optional-key :status)   (s/enum "sold" "pending" "available")}}
+           {:status (s/eq 400) :body nil}
+           {:status (s/eq 404) :body nil}
+           {:status (s/eq 405) :body nil}]})))


### PR DESCRIPTION
I'm keen to use Martian for a project at work, but the specs that I have to interact with are OpenAPI3 rather than Swagger2. I tried using a converted from OpenAPI to Swagger, but they ended up yielding sub-par schemas (lots of optional keys and maybes that didn't match required fields in the spec).

In order to make Martian fit our project better, I've put together this `martian.openapi` namespace. I'm not claiming that it's a full implementation of the spec, and in particular the "content types" thing was a bit hastily thrown together, but this seems to be sufficient for what I need, and I figured it might be helpful for someone else, too.

I took inspiration from the `martian.swagger` namespace, but no code is shared with it.