### PR TITLE
OpenAPI parameters

### DIFF
--- a/core/src/martian/openapi.cljc
+++ b/core/src/martian/openapi.cljc
@@ -115,7 +115,7 @@
           ;; which aren't the associated OPTIONS call.
           :when (and (:operationId definition)
                      (not= :options method))
-          :let [parameters (group-by :in (:parameters definition))
+          :let [parameters (group-by (comp keyword :in) (:parameters definition))
                 body       (process-body (:requestBody definition) components (:encodes content-types))
                 responses  (process-responses (:responses definition) components (:decodes content-types))]]
       {:path-parts         (vec (tokenise-path url))

--- a/core/test-resources/openapi2.json
+++ b/core/test-resources/openapi2.json
@@ -1,0 +1,55 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "My API",
+    "version": "1"
+  },
+  "paths": {
+    "/project/{projectKey}": {
+      "get": {
+        "summary": "Get specific values from a configuration for a specific project",
+        "operationId": "getProjectConfiguration",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "string"
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "description": "Obtains values corresponding to these keys from a project's configuration",
+            "schema": {
+              "type": "string",
+              "format": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Configuration for the specified project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Refusing access to requested resource, perhaps due to insufficient privilege"
+          },
+          "404": {
+            "description": "Requested resource was not found"
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/test/martian/openapi_test.cljc
+++ b/core/test/martian/openapi_test.cljc
@@ -60,3 +60,28 @@
                (->> (filter #(= (:route-name %) :update-pet)))
                first
                (select-keys [:consumes :produces]))))))
+
+(deftest openapi-two-test
+  (testing "parses parameters which are different somehow"
+    (is (= {:description nil,
+            :method :get,
+            :produces ["application/json"],
+            :path-schema {:projectId s/Str},
+            :query-schema {(s/optional-key :key) s/Str},
+            :form-schema {},
+            :path-parts ["/project/" :projectKey],
+            :headers-schema {},
+            :consumes [nil],
+            :summary "Get specific values from a configuration for a specific project",
+            :body-schema nil,
+            :route-name :get-project-configuration,
+            :response-schemas
+            [{:status (s/eq 200), :body s/Str}
+             {:status (s/eq 403), :body nil}
+             {:status (s/eq 404), :body nil}]}
+           (-> (parse-string (slurp (io/resource "openapi2.json")))
+               (openapi->handlers {:encodes ["application/json" "application/octet-stream"]
+                                   :decodes ["application/json" "application/octet-stream"]})
+               (->> (filter #(= (:route-name %) :get-project-configuration)))
+               first
+               (dissoc :openapi-definition))))))

--- a/core/test/martian/openapi_test.cljc
+++ b/core/test/martian/openapi_test.cljc
@@ -61,8 +61,8 @@
                first
                (select-keys [:consumes :produces]))))))
 
-(deftest openapi-two-test
-  (testing "parses parameters which are different somehow"
+(deftest openapi-parameters-test
+  (testing "parses parameters"
     (is (= {:description nil,
             :method :get,
             :produces ["application/json"],


### PR DESCRIPTION
Keywordizing broke the parameters for OpenAPI parsing. The test didn't have any parameters, so it wasn't spotted. Closes #93