### PR TITLE
add way to pass extra options when fetching the swagger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 **/.cljs_nashorn_repl/
 **/nashorn_code_cache/
 /**/out/
+.clj-kondo/.cache
+/.lsp/.cache

--- a/clj-http-lite/src/martian/clj_http_lite.clj
+++ b/clj-http-lite/src/martian/clj_http_lite.clj
@@ -23,8 +23,8 @@
 (defn bootstrap [api-root concise-handlers & [opts]]
   (martian/bootstrap api-root concise-handlers (merge default-opts opts)))
 
-(defn bootstrap-openapi [url & [opts]]
-  (let [definition (-> (http/get url) :body (json/parse-string keyword)) ;; clj-http-lite does not support {:as :json} body conversion (yet) so we do it right here
+(defn bootstrap-openapi [url & [opts get-swagger-opts]]
+  (let [definition (-> (http/get url (or get-swagger-opts {})) :body (json/parse-string keyword)) ;; clj-http-lite does not support {:as :json} body conversion (yet) so we do it right here
         {:keys [scheme server-name server-port]} (http/parse-url url)
         base-url (format "%s://%s%s%s" (name scheme) server-name (if server-port (str ":" server-port) "")
                          (if (openapi-schema? definition)

--- a/clj-http/src/martian/clj_http.clj
+++ b/clj-http/src/martian/clj_http.clj
@@ -18,8 +18,8 @@
 (defn bootstrap [api-root concise-handlers & [opts]]
   (martian/bootstrap api-root concise-handlers (merge default-opts opts)))
 
-(defn bootstrap-openapi [url & [opts]]
-  (let [definition (:body (http/get url {:as :json}))
+(defn bootstrap-openapi [url & [opts get-swagger-opts]]
+  (let [definition (:body (http/get url (merge {:as :json} get-swagger-opts)))
         {:keys [scheme server-name server-port]} (http/parse-url url)
         base-url (format "%s://%s%s%s" (name scheme) server-name (if server-port (str ":" server-port) "")
                          (if (openapi-schema? definition)

--- a/cljs-http/src/martian/cljs_http.cljs
+++ b/cljs-http/src/martian/cljs_http.cljs
@@ -28,8 +28,8 @@
 (defn bootstrap [api-root concise-handlers & [opts]]
   (martian/bootstrap api-root concise-handlers (merge default-opts opts)))
 
-(defn bootstrap-openapi [url & [{:keys [trim-base-url?] :as opts}]]
-  (go (let [definition (:body (<! (http/get url {:as :json})))
+(defn bootstrap-openapi [url & [{:keys [trim-base-url?] :as opts} get-swagger-opts]]
+  (go (let [definition (:body (<! (http/get url (merge {:as :json} get-swagger-opts))))
             {:keys [scheme server-name server-port]} (http/parse-url url)
             raw-base-url (str (when-not (re-find #"^/" url)
                                 (str (name scheme) "://" server-name (when server-port (str ":" server-port))))

--- a/hato/src/martian/hato.clj
+++ b/hato/src/martian/hato.clj
@@ -60,8 +60,8 @@
 (defn bootstrap [api-root concise-handlers & [opts]]
   (martian/bootstrap api-root concise-handlers (merge default-opts opts)))
 
-(defn bootstrap-openapi [url & [opts]]
-  (let [definition (:body (http/get url {:as :json}))
+(defn bootstrap-openapi [url & [opts get-swagger-opts]]
+  (let [definition (:body (http/get url (merge {:as :json} get-swagger-opts)))
         {:keys [scheme server-name server-port]} (parse-url url)
         base-url (format "%s://%s%s%s" (name scheme) server-name (if server-port (str ":" server-port) "")
                          (if (openapi-schema? definition)

--- a/httpkit/src/martian/httpkit.clj
+++ b/httpkit/src/martian/httpkit.clj
@@ -38,8 +38,10 @@
 (defn bootstrap [api-root concise-handlers & [opts]]
   (martian/bootstrap api-root concise-handlers (merge default-opts opts)))
 
-(defn bootstrap-openapi [url & [opts]]
-  (let [definition @(http/get url {:as :text} (fn [{:keys [body]}] (json/decode body keyword)))
+(defn bootstrap-openapi [url & [opts get-swagger-opts]]
+  (let [definition @(http/get url
+                              (merge {:as :text} get-swagger-opts)
+                              (fn [{:keys [body]}] (json/decode body keyword)))
         {:keys [scheme server-name server-port]} (parse-url url)
         base-url (format "%s://%s%s%s" (name scheme) server-name (if server-port (str ":" server-port) "")
                          (if (openapi-schema? definition)


### PR DESCRIPTION
This allows to pass extra options to the http/get that does the fetching of the swagger file.

# TODO / questions

- [x] This function is defined separately for each HTTP library used, should it be changed in all of them?
- [x] add a test