### PR TITLE
Bump cheshire and fix jackson CVE-2020-28491

### DIFF
--- a/clj-http-lite/project.clj
+++ b/clj-http-lite/project.clj
@@ -6,7 +6,7 @@
   :plugins [[lein-modules "0.3.11"]]
   :dependencies [[com.github.oliyh/martian :version]
                  [org.martinklepsch/clj-http-lite "0.4.3"]
-                 [cheshire "5.10.0"]]
+                 [cheshire "5.10.1"]]
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.10.3"]]}
              :dev {:source-paths ["../test-common"]
                    :exclusions [[org.clojure/tools.reader]]

--- a/clj-http/project.clj
+++ b/clj-http/project.clj
@@ -6,7 +6,7 @@
   :plugins [[lein-modules "0.3.11"]]
   :dependencies [[com.github.oliyh/martian :version]
                  [clj-http "3.12.3"]
-                 [cheshire "5.10.0"]]
+                 [cheshire "5.10.1"]]
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.10.3"]]}
              :dev {:source-paths ["../test-common"]
                    :exclusions [[org.clojure/tools.reader]]

--- a/core/project.clj
+++ b/core/project.clj
@@ -10,7 +10,7 @@
                   :exclusions [com.fasterxml.jackson.core/jackson-databind]]
                  [org.clojure/spec.alpha "0.2.194"]
                  [camel-snake-kebab "0.4.2"]
-                 [cheshire "5.10.0"]
+                 [cheshire "5.10.1"]
 
                  [com.cognitect/transit-clj "1.0.324"]
                  [com.cognitect/transit-cljs "0.8.269"]

--- a/hato/project.clj
+++ b/hato/project.clj
@@ -6,7 +6,7 @@
   :plugins [[lein-modules "0.3.11"]]
   :dependencies [[com.github.oliyh/martian :version]
                  [hato "0.8.2"]
-                 [cheshire "5.10.0"]]
+                 [cheshire "5.10.1"]]
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.10.3"]]}
              :dev {:source-paths ["../test-common"]
                    :exclusions [[org.clojure/tools.reader]]

--- a/httpkit/project.clj
+++ b/httpkit/project.clj
@@ -6,7 +6,7 @@
   :plugins [[lein-modules "0.3.11"]]
   :dependencies [[com.github.oliyh/martian :version]
                  [http-kit "2.5.3"]
-                 [cheshire "5.10.0"]]
+                 [cheshire "5.10.1"]]
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.10.3"]]}
              :dev {:source-paths ["../test-common"]
                    :exclusions [[org.clojure/tools.reader]]


### PR DESCRIPTION
Bump cheshire to latest release which includes this fix: 

https://github.com/dakrone/cheshire/commit/73daea7eba04ab214f38a9d3a1398329224f7c52