### PR TITLE
Add support for absolute OpenAPI server URLs

### DIFF
--- a/clj-http-lite/src/martian/clj_http_lite.clj
+++ b/clj-http-lite/src/martian/clj_http_lite.clj
@@ -24,10 +24,10 @@
 (defn bootstrap [api-root concise-handlers & [opts]]
   (martian/bootstrap api-root concise-handlers (merge default-opts opts)))
 
-(defn bootstrap-openapi [url & [opts get-swagger-opts]]
+(defn bootstrap-openapi [url & [{:keys [server-url] :as opts} get-swagger-opts]]
   (let [definition (-> (http/get url (or get-swagger-opts {})) :body (json/parse-string keyword)) ;; clj-http-lite does not support {:as :json} body conversion (yet) so we do it right here
         {:keys [scheme server-name server-port]} (http/parse-url url)
-        api-root (or (:server-url opts) (openapi/base-url definition))
+        api-root (or server-url (openapi/base-url definition))
         base-url (if (and (openapi-schema? definition) (not (string/starts-with? api-root "/")))
                    api-root
                    (format "%s://%s%s%s" (name scheme) server-name (if server-port (str ":" server-port) "")

--- a/clj-http-lite/src/martian/clj_http_lite.clj
+++ b/clj-http-lite/src/martian/clj_http_lite.clj
@@ -1,6 +1,7 @@
 (ns martian.clj-http-lite
   (:require [clj-http.lite.client :as http]
             [cheshire.core :as json]
+            [clojure.string :as string]
             [martian.core :as martian]
             [martian.interceptors :as interceptors]
             [martian.openapi :refer [openapi-schema?] :as openapi]))
@@ -26,10 +27,13 @@
 (defn bootstrap-openapi [url & [opts get-swagger-opts]]
   (let [definition (-> (http/get url (or get-swagger-opts {})) :body (json/parse-string keyword)) ;; clj-http-lite does not support {:as :json} body conversion (yet) so we do it right here
         {:keys [scheme server-name server-port]} (http/parse-url url)
-        base-url (format "%s://%s%s%s" (name scheme) server-name (if server-port (str ":" server-port) "")
-                         (if (openapi-schema? definition)
-                           (openapi/base-url definition)
-                           (get definition :basePath "")))]
+        api-root (or (:server-url opts) (openapi/base-url definition))
+        base-url (if (and (openapi-schema? definition) (not (string/starts-with? api-root "/")))
+                   api-root
+                   (format "%s://%s%s%s" (name scheme) server-name (if server-port (str ":" server-port) "")
+                           (if (openapi-schema? definition)
+                             api-root
+                             (get definition :basePath ""))))]
     (martian/bootstrap-openapi base-url definition (merge default-opts opts))))
 
 (def bootstrap-swagger bootstrap-openapi)

--- a/clj-http-lite/src/martian/clj_http_lite.clj
+++ b/clj-http-lite/src/martian/clj_http_lite.clj
@@ -30,10 +30,11 @@
         api-root (or server-url (openapi/base-url definition))
         base-url (if (and (openapi-schema? definition) (not (string/starts-with? api-root "/")))
                    api-root
-                   (format "%s://%s%s%s" (name scheme) server-name (if server-port (str ":" server-port) "")
-                           (if (openapi-schema? definition)
-                             api-root
-                             (get definition :basePath ""))))]
+                   (str (name scheme) "://"
+                        server-name (when server-port (str ":" server-port))
+                        (if (openapi-schema? definition)
+                          api-root
+                          (get definition :basePath ""))))]
     (martian/bootstrap-openapi base-url definition (merge default-opts opts))))
 
 (def bootstrap-swagger bootstrap-openapi)

--- a/clj-http-lite/test/martian/clj_http_lite_test.clj
+++ b/clj-http-lite/test/martian/clj_http_lite_test.clj
@@ -2,7 +2,7 @@
   (:require [martian.clj-http-lite :as martian-http]
             [martian.core :as martian]
             [martian.encoders :as encoders]
-            [martian.server-stub :refer [with-server swagger-url openapi-url]]
+            [martian.server-stub :refer [with-server swagger-url openapi-url openapi-test-url]]
             [martian.test-utils :refer [input-stream->byte-array]]
             [clojure.test :refer [deftest testing is use-fixtures]]))
 
@@ -36,7 +36,12 @@
              (:body response))))))
 
 (deftest openapi-bootstrap-test
-  (let [m (martian-http/bootstrap-openapi openapi-url)]
+  (let [m (martian-http/bootstrap-openapi openapi-url)
+        mt (martian-http/bootstrap-openapi openapi-test-url)]
+
+    (is (= "https://sandbox.example.com"
+           (:api-root mt)) "check absolute server url")
+
 
     (is (= "http://localhost:8888/openapi/v3"
            (:api-root m)))

--- a/clj-http-lite/test/martian/clj_http_lite_test.clj
+++ b/clj-http-lite/test/martian/clj_http_lite_test.clj
@@ -36,19 +36,19 @@
              (:body response))))))
 
 (deftest openapi-bootstrap-test
-  (let [m (martian-http/bootstrap-openapi openapi-url)
-        mt (martian-http/bootstrap-openapi openapi-test-url)
-        mt1 (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"})
-        mt2 (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"})]
+  (let [m (martian-http/bootstrap-openapi openapi-url)]
 
     (is (= "https://sandbox.example.com"
-           (:api-root mt)) "check absolute server url")
+           (:api-root (martian-http/bootstrap-openapi openapi-test-url)))
+        "check absolute server url")
 
     (is (= "https://sandbox.com"
-           (:api-root mt1)) "check absolute server url via opts")
+           (:api-root (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"})))
+        "check absolute server url via opts")
 
     (is (= "http://localhost:8888/v3.1"
-           (:api-root mt2)) "check relative server url via opts")
+           (:api-root (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"})))
+        "check relative server url via opts")
 
     (is (= "http://localhost:8888/openapi/v3"
            (:api-root m)))

--- a/clj-http-lite/test/martian/clj_http_lite_test.clj
+++ b/clj-http-lite/test/martian/clj_http_lite_test.clj
@@ -37,11 +37,18 @@
 
 (deftest openapi-bootstrap-test
   (let [m (martian-http/bootstrap-openapi openapi-url)
-        mt (martian-http/bootstrap-openapi openapi-test-url)]
+        mt (martian-http/bootstrap-openapi openapi-test-url)
+        mt1 (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"})
+        mt2 (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"})]
 
     (is (= "https://sandbox.example.com"
            (:api-root mt)) "check absolute server url")
 
+    (is (= "https://sandbox.com"
+           (:api-root mt1)) "check absolute server url via opts")
+
+    (is (= "http://localhost:8888/v3.1"
+           (:api-root mt2)) "check relative server url via opts")
 
     (is (= "http://localhost:8888/openapi/v3"
            (:api-root m)))

--- a/clj-http/src/martian/clj_http.clj
+++ b/clj-http/src/martian/clj_http.clj
@@ -1,9 +1,8 @@
 (ns martian.clj-http
   (:require [clj-http.client :as http]
-            [clojure.string :as string]
             [martian.core :as martian]
             [martian.interceptors :as interceptors]
-            [martian.openapi :refer [openapi-schema?] :as openapi])
+            [martian.openapi :as openapi])
   (:import [java.io ByteArrayInputStream]))
 
 (def perform-request
@@ -21,15 +20,7 @@
 
 (defn bootstrap-openapi [url & [{:keys [server-url] :as opts} get-swagger-opts]]
   (let [definition (:body (http/get url (merge {:as :json} get-swagger-opts)))
-        {:keys [scheme server-name server-port]} (http/parse-url url)
-        api-root (or server-url (openapi/base-url definition))
-        base-url (if (and (openapi-schema? definition) (not (string/starts-with? api-root "/")))
-                   api-root
-                   (str (name scheme)  "://"
-                        server-name (when server-port (str ":" server-port))
-                        (if (openapi-schema? definition)
-                          api-root
-                          (get definition :basePath ""))))]
+        base-url (openapi/base-url url server-url definition)]
     (martian/bootstrap-openapi base-url definition (merge default-opts opts))))
 
 (def bootstrap-swagger bootstrap-openapi)

--- a/clj-http/src/martian/clj_http.clj
+++ b/clj-http/src/martian/clj_http.clj
@@ -19,10 +19,10 @@
 (defn bootstrap [api-root concise-handlers & [opts]]
   (martian/bootstrap api-root concise-handlers (merge default-opts opts)))
 
-(defn bootstrap-openapi [url & [opts get-swagger-opts]]
+(defn bootstrap-openapi [url & [{:keys [server-url] :as opts} get-swagger-opts]]
   (let [definition (:body (http/get url (merge {:as :json} get-swagger-opts)))
         {:keys [scheme server-name server-port]} (http/parse-url url)
-        api-root (or (:server-url opts) (openapi/base-url definition))
+        api-root (or server-url (openapi/base-url definition))
         base-url (if (and (openapi-schema? definition) (not (string/starts-with? api-root "/")))
                    api-root
                    (format "%s://%s%s%s" (name scheme) server-name (if server-port (str ":" server-port) "")

--- a/clj-http/src/martian/clj_http.clj
+++ b/clj-http/src/martian/clj_http.clj
@@ -25,10 +25,11 @@
         api-root (or server-url (openapi/base-url definition))
         base-url (if (and (openapi-schema? definition) (not (string/starts-with? api-root "/")))
                    api-root
-                   (format "%s://%s%s%s" (name scheme) server-name (if server-port (str ":" server-port) "")
-                           (if (openapi-schema? definition)
-                             api-root
-                             (get definition :basePath ""))))]
+                   (str (name scheme)  "://"
+                        server-name (when server-port (str ":" server-port))
+                        (if (openapi-schema? definition)
+                          api-root
+                          (get definition :basePath ""))))]
     (martian/bootstrap-openapi base-url definition (merge default-opts opts))))
 
 (def bootstrap-swagger bootstrap-openapi)

--- a/clj-http/test/martian/clj_http_test.clj
+++ b/clj-http/test/martian/clj_http_test.clj
@@ -2,7 +2,7 @@
   (:require [martian.clj-http :as martian-http]
             [martian.core :as martian]
             [martian.encoders :as encoders]
-            [martian.server-stub :refer [with-server swagger-url openapi-url]]
+            [martian.server-stub :refer [with-server swagger-url openapi-url openapi-test-url]]
             [martian.test-utils :refer [input-stream->byte-array]]
             [clojure.test :refer [deftest testing is use-fixtures]]))
 
@@ -37,7 +37,12 @@
              (:body response))))))
 
 (deftest openapi-bootstrap-test
-  (let [m (martian-http/bootstrap-openapi openapi-url)]
+  (let [m (martian-http/bootstrap-openapi openapi-url)
+        mt (martian-http/bootstrap-openapi openapi-test-url)]
+
+    (is (= "https://sandbox.example.com"
+           (:api-root mt)) "check absolute server url")
+
 
     (is (= "http://localhost:8888/openapi/v3"
            (:api-root m)))

--- a/clj-http/test/martian/clj_http_test.clj
+++ b/clj-http/test/martian/clj_http_test.clj
@@ -38,11 +38,18 @@
 
 (deftest openapi-bootstrap-test
   (let [m (martian-http/bootstrap-openapi openapi-url)
-        mt (martian-http/bootstrap-openapi openapi-test-url)]
+        mt (martian-http/bootstrap-openapi openapi-test-url)
+        mt1 (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"})
+        mt2 (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"})]
 
     (is (= "https://sandbox.example.com"
            (:api-root mt)) "check absolute server url")
 
+    (is (= "https://sandbox.com"
+           (:api-root mt1)) "check absolute server url via opts")
+
+    (is (= "http://localhost:8888/v3.1"
+           (:api-root mt2)) "check relative server url via opts")
 
     (is (= "http://localhost:8888/openapi/v3"
            (:api-root m)))

--- a/clj-http/test/martian/clj_http_test.clj
+++ b/clj-http/test/martian/clj_http_test.clj
@@ -37,19 +37,19 @@
              (:body response))))))
 
 (deftest openapi-bootstrap-test
-  (let [m (martian-http/bootstrap-openapi openapi-url)
-        mt (martian-http/bootstrap-openapi openapi-test-url)
-        mt1 (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"})
-        mt2 (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"})]
+  (let [m (martian-http/bootstrap-openapi openapi-url)]
 
     (is (= "https://sandbox.example.com"
-           (:api-root mt)) "check absolute server url")
+           (:api-root (martian-http/bootstrap-openapi openapi-test-url)))
+        "check absolute server url")
 
     (is (= "https://sandbox.com"
-           (:api-root mt1)) "check absolute server url via opts")
+           (:api-root (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"})))
+        "check absolute server url via opts")
 
     (is (= "http://localhost:8888/v3.1"
-           (:api-root mt2)) "check relative server url via opts")
+           (:api-root (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"})))
+        "check relative server url via opts")
 
     (is (= "http://localhost:8888/openapi/v3"
            (:api-root m)))

--- a/cljs-http-promise/src/martian/cljs_http_promise.cljs
+++ b/cljs-http-promise/src/martian/cljs_http_promise.cljs
@@ -2,7 +2,7 @@
   (:require [cljs-http.client :as http]
             [martian.core :as martian]
             [martian.interceptors :as i]
-            [martian.openapi :refer [openapi-schema?] :as openapi]
+            [martian.openapi :as openapi]
             [tripod.context :as tc]
             [clojure.string :as string]
             [promesa.core :as prom]))
@@ -32,15 +32,7 @@
   (prom/then (http/get url {:as :json})
              (fn [response]
                (let [definition (:body response)
-                     {:keys [scheme server-name server-port]} (http/parse-url url)
-                     api-root (or server-url (openapi/base-url definition))
-                     raw-base-url (if (and (openapi-schema? definition) (not (string/starts-with? api-root "/")))
-                                    api-root
-                                    (str (name scheme) "://"
-                                         server-name (when server-port (str ":" server-port))
-                                         (if (openapi-schema? definition)
-                                           api-root
-                                           (get definition :basePath ""))))
+                     raw-base-url (openapi/base-url url server-url definition)
                      base-url (if trim-base-url?
                                 (string/replace raw-base-url #"/$" "")
                                 raw-base-url)]

--- a/cljs-http-promise/test/martian/cljs_http_promise_test.cljs
+++ b/cljs-http-promise/test/martian/cljs_http_promise_test.cljs
@@ -29,19 +29,21 @@
 
 (deftest openapi-bootstrap-test
   (async done
-         (-> (prom/let [m (martian-http/bootstrap-openapi openapi-url)
-                        mt (martian-http/bootstrap-openapi openapi-test-url)
-                        mt1 (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"})
-                        mt2 (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"})]
+         (-> (martian-http/bootstrap-openapi openapi-test-url)
+             (prom/then (fn [m]
+                          (is (= "https://sandbox.example.com"
+                                 (:api-root m)) "check absolute server url"))))
 
-               (is (= "https://sandbox.example.com"
-                      (:api-root mt)) "check absolute server url")
+         (-> (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"})
+             (prom/then (fn [m]
+                          (is (= "https://sandbox.com"
+                                 (:api-root m)) "check absolute server url via opts"))))
+         (-> (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"})
+             (prom/then (fn [m]
+                          (is (= "http://localhost:8888/v3.1"
+                                 (:api-root m)) "check relative server url via opts"))))
 
-               (is (= "https://sandbox.com"
-                      (:api-root mt1)) "check absolute server url via opts")
-
-               (is (= "http://localhost:8888/v3.1"
-                      (:api-root mt2)) "check relative server url via opts")
+         (-> (prom/let [m (martian-http/bootstrap-openapi openapi-url)]
 
                (is (= "http://localhost:8888/openapi/v3"
                       (:api-root m)))

--- a/cljs-http/src/martian/cljs_http.cljs
+++ b/cljs-http/src/martian/cljs_http.cljs
@@ -30,15 +30,7 @@
 
 (defn bootstrap-openapi [url & [{:keys [server-url trim-base-url?] :as opts} get-swagger-opts]]
   (go (let [definition (:body (<! (http/get url (merge {:as :json} get-swagger-opts))))
-            {:keys [scheme server-name server-port]} (http/parse-url url)
-            api-root (or server-url (openapi/base-url definition))
-            raw-base-url (if (and (openapi-schema? definition) (not (string/starts-with? api-root "/")))
-                           api-root
-                           (str (name scheme) "://"
-                                server-name (when server-port (str ":" server-port))
-                                (if (openapi-schema? definition)
-                                  api-root
-                                  (get definition :basePath ""))))
+            raw-base-url (openapi/base-url url server-url definition)
             base-url (if trim-base-url?
                        (string/replace raw-base-url #"/$" "")
                        raw-base-url)]

--- a/cljs-http/src/martian/cljs_http.cljs
+++ b/cljs-http/src/martian/cljs_http.cljs
@@ -5,7 +5,7 @@
             [martian.interceptors :as i]
             [martian.openapi :refer [openapi-schema?] :as openapi]
             [tripod.context :as tc]
-            [clojure.string :as str])
+            [clojure.string :as string])
   (:require-macros [cljs.core.async.macros :refer [go]]))
 
 (def ^:private go-async
@@ -28,16 +28,19 @@
 (defn bootstrap [api-root concise-handlers & [opts]]
   (martian/bootstrap api-root concise-handlers (merge default-opts opts)))
 
-(defn bootstrap-openapi [url & [{:keys [trim-base-url?] :as opts} get-swagger-opts]]
+(defn bootstrap-openapi [url & [{:keys [server-url trim-base-url?] :as opts} get-swagger-opts]]
   (go (let [definition (:body (<! (http/get url (merge {:as :json} get-swagger-opts))))
             {:keys [scheme server-name server-port]} (http/parse-url url)
-            raw-base-url (str (when-not (re-find #"^/" url)
-                                (str (name scheme) "://" server-name (when server-port (str ":" server-port))))
-                              (if (openapi-schema? definition)
-                                (openapi/base-url definition)
-                                (get definition :basePath "")))
+            api-root (or server-url (openapi/base-url definition))
+            raw-base-url (if (and (openapi-schema? definition) (not (string/starts-with? api-root "/")))
+                           api-root
+                           (str (name scheme) "://"
+                                server-name (when server-port (str ":" server-port))
+                                (if (openapi-schema? definition)
+                                  api-root
+                                  (get definition :basePath ""))))
             base-url (if trim-base-url?
-                       (str/replace raw-base-url #"/$" "")
+                       (string/replace raw-base-url #"/$" "")
                        raw-base-url)]
         (martian/bootstrap-openapi base-url definition (merge default-opts opts)))))
 

--- a/cljs-http/test/martian/cljs_http_test.cljs
+++ b/cljs-http/test/martian/cljs_http_test.cljs
@@ -30,19 +30,19 @@
 
 (deftest openapi-bootstrap-test
   (async done
-         (go (let [m (<! (martian-http/bootstrap-openapi openapi-url))
-                   mt (<! (martian-http/bootstrap-openapi openapi-test-url))
-                   mt1 (<! (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"}))
-                   mt2 (<! (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"}))]
+         (go (let [m (<! (martian-http/bootstrap-openapi openapi-url))]
 
                (is (= "https://sandbox.example.com"
-                      (:api-root mt)) "check absolute server url")
+                      (:api-root (<! (martian-http/bootstrap-openapi openapi-test-url))))
+                   "check absolute server url")
 
                (is (= "https://sandbox.com"
-                      (:api-root mt1)) "check absolute server url via opts")
+                      (:api-root (<! (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"}))))
+                   "check absolute server url via opts")
 
                (is (= "http://localhost:8888/v3.1"
-                      (:api-root mt2)) "check relative server url via opts")
+                      (:api-root (<! (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"}))))
+                   "check relative server url via opts")
 
                (is (= "http://localhost:8888/openapi/v3"
                       (:api-root m)))

--- a/cljs-http/test/martian/cljs_http_test.cljs
+++ b/cljs-http/test/martian/cljs_http_test.cljs
@@ -31,5 +31,5 @@
                       (:api-root m)))
 
                (is (contains? (set (map first (martian/explore m)))
-                              :get-order-by-id))))
-         (done)))
+                              :get-order-by-id)))
+             (done))))

--- a/cljs-http/test/martian/cljs_http_test.cljs
+++ b/cljs-http/test/martian/cljs_http_test.cljs
@@ -5,9 +5,14 @@
             [cljs.core.async :refer [<! timeout]])
   (:require-macros [cljs.core.async.macros :refer [go]]))
 
+(def swagger-url "http://localhost:8888/swagger.json")
+(def openapi-url "http://localhost:8888/openapi.json")
+(def openapi-test-url "http://localhost:8888/openapi-test.json")
+
+
 (deftest swagger-http-test
   (async done
-         (go (let [m (<! (martian-http/bootstrap-swagger "http://localhost:8888/swagger.json"))]
+         (go (let [m (<! (martian-http/bootstrap-swagger swagger-url))]
 
                (let [response (<! (martian/response-for m :create-pet {:pet {:name "Doggy McDogFace"
                                                                              :type "Dog"
@@ -25,7 +30,19 @@
 
 (deftest openapi-bootstrap-test
   (async done
-         (go (let [m (<! (martian-http/bootstrap-openapi "http://localhost:8888/openapi.json"))]
+         (go (let [m (<! (martian-http/bootstrap-openapi openapi-url))
+                   mt (<! (martian-http/bootstrap-openapi openapi-test-url))
+                   mt1 (<! (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"}))
+                   mt2 (<! (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"}))]
+
+               (is (= "https://sandbox.example.com"
+                      (:api-root mt)) "check absolute server url")
+
+               (is (= "https://sandbox.com"
+                      (:api-root mt1)) "check absolute server url via opts")
+
+               (is (= "http://localhost:8888/v3.1"
+                      (:api-root mt2)) "check relative server url via opts")
 
                (is (= "http://localhost:8888/openapi/v3"
                       (:api-root m)))

--- a/core/project.clj
+++ b/core/project.clj
@@ -11,6 +11,7 @@
                  [org.clojure/spec.alpha "0.2.194"]
                  [camel-snake-kebab "0.4.2"]
                  [cheshire "5.10.1"]
+                 [lambdaisland/uri "1.12.89"]
 
                  [com.cognitect/transit-clj "1.0.324"]
                  [com.cognitect/transit-cljs "0.8.269"]

--- a/hato/src/martian/hato.clj
+++ b/hato/src/martian/hato.clj
@@ -3,6 +3,7 @@
             [martian.core :as martian]
             [martian.interceptors :as interceptors]
             [martian.openapi :refer [openapi-schema?] :as openapi]
+            [clojure.string :as string]
             [clojure.walk :refer [keywordize-keys stringify-keys]]
             [tripod.context :as tc])
   (:import [java.net URL]))
@@ -67,10 +68,13 @@
 (defn bootstrap-openapi [url & [opts get-swagger-opts]]
   (let [definition (:body (http/get url (merge {:as :json} get-swagger-opts)))
         {:keys [scheme server-name server-port]} (parse-url url)
-        base-url (format "%s://%s%s%s" (name scheme) server-name (if server-port (str ":" server-port) "")
-                         (if (openapi-schema? definition)
-                           (openapi/base-url definition)
-                           (get definition :basePath "")))]
+        api-root (or (:server-url opts) (openapi/base-url definition))
+        base-url (if (and (openapi-schema? definition) (not (string/starts-with? api-root "/")))
+                   api-root
+                   (format "%s://%s%s%s" (name scheme) server-name (if server-port (str ":" server-port) "")
+                           (if (openapi-schema? definition)
+                             api-root
+                             (get definition :basePath ""))))]
     (martian/bootstrap-openapi base-url definition (merge default-opts opts))))
 
 (def bootstrap-swagger bootstrap-openapi)

--- a/hato/src/martian/hato.clj
+++ b/hato/src/martian/hato.clj
@@ -65,10 +65,10 @@
 (defn bootstrap [api-root concise-handlers & [opts]]
   (martian/bootstrap api-root concise-handlers (merge default-opts opts)))
 
-(defn bootstrap-openapi [url & [opts get-swagger-opts]]
+(defn bootstrap-openapi [url & [{:keys [server-url] :as opts} get-swagger-opts]]
   (let [definition (:body (http/get url (merge {:as :json} get-swagger-opts)))
         {:keys [scheme server-name server-port]} (parse-url url)
-        api-root (or (:server-url opts) (openapi/base-url definition))
+        api-root (or server-url (openapi/base-url definition))
         base-url (if (and (openapi-schema? definition) (not (string/starts-with? api-root "/")))
                    api-root
                    (format "%s://%s%s%s" (name scheme) server-name (if server-port (str ":" server-port) "")

--- a/hato/src/martian/hato.clj
+++ b/hato/src/martian/hato.clj
@@ -71,10 +71,11 @@
         api-root (or server-url (openapi/base-url definition))
         base-url (if (and (openapi-schema? definition) (not (string/starts-with? api-root "/")))
                    api-root
-                   (format "%s://%s%s%s" (name scheme) server-name (if server-port (str ":" server-port) "")
-                           (if (openapi-schema? definition)
-                             api-root
-                             (get definition :basePath ""))))]
+                   (str (name scheme) "://"
+                        server-name (when server-port (str ":" server-port))
+                        (if (openapi-schema? definition)
+                          api-root
+                          (get definition :basePath ""))))]
     (martian/bootstrap-openapi base-url definition (merge default-opts opts))))
 
 (def bootstrap-swagger bootstrap-openapi)

--- a/hato/test/martian/hato_test.clj
+++ b/hato/test/martian/hato_test.clj
@@ -92,10 +92,18 @@
 
 (deftest openapi-bootstrap-test
   (let [m (martian-http/bootstrap-openapi openapi-url)
-        mt (martian-http/bootstrap-openapi openapi-test-url)]
+        mt (martian-http/bootstrap-openapi openapi-test-url)
+        mt1 (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"})
+        mt2 (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"})]
 
     (is (= "https://sandbox.example.com"
            (:api-root mt)) "check absolute server url")
+
+    (is (= "https://sandbox.com"
+           (:api-root mt1)) "check absolute server url via opts")
+
+    (is (= "http://localhost:8888/v3.1"
+           (:api-root mt2)) "check relative server url via opts")
 
     (is (= "http://localhost:8888/openapi/v3"
            (:api-root m)))

--- a/hato/test/martian/hato_test.clj
+++ b/hato/test/martian/hato_test.clj
@@ -91,19 +91,19 @@
                @(martian/response-for m :get-pet {:id -1})))))))
 
 (deftest openapi-bootstrap-test
-  (let [m (martian-http/bootstrap-openapi openapi-url)
-        mt (martian-http/bootstrap-openapi openapi-test-url)
-        mt1 (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"})
-        mt2 (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"})]
+  (let [m (martian-http/bootstrap-openapi openapi-url)]
 
     (is (= "https://sandbox.example.com"
-           (:api-root mt)) "check absolute server url")
+           (:api-root (martian-http/bootstrap-openapi openapi-test-url)))
+        "check absolute server url")
 
     (is (= "https://sandbox.com"
-           (:api-root mt1)) "check absolute server url via opts")
+           (:api-root (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"})))
+        "check absolute server url via opts")
 
     (is (= "http://localhost:8888/v3.1"
-           (:api-root mt2)) "check relative server url via opts")
+           (:api-root (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"})))
+        "check relative server url via opts")
 
     (is (= "http://localhost:8888/openapi/v3"
            (:api-root m)))

--- a/hato/test/martian/hato_test.clj
+++ b/hato/test/martian/hato_test.clj
@@ -2,7 +2,7 @@
   (:require [martian.hato :as martian-http]
             [martian.core :as martian]
             [martian.encoders :as encoders]
-            [martian.server-stub :refer [with-server swagger-url openapi-url]]
+            [martian.server-stub :refer [with-server swagger-url openapi-url openapi-test-url]]
             [martian.test-utils :refer [input-stream->byte-array]]
             [clojure.test :refer [deftest testing is use-fixtures]]))
 
@@ -91,7 +91,11 @@
                @(martian/response-for m :get-pet {:id -1})))))))
 
 (deftest openapi-bootstrap-test
-  (let [m (martian-http/bootstrap-openapi openapi-url)]
+  (let [m (martian-http/bootstrap-openapi openapi-url)
+        mt (martian-http/bootstrap-openapi openapi-test-url)]
+
+    (is (= "https://sandbox.example.com"
+           (:api-root mt)) "check absolute server url")
 
     (is (= "http://localhost:8888/openapi/v3"
            (:api-root m)))

--- a/httpkit/src/martian/httpkit.clj
+++ b/httpkit/src/martian/httpkit.clj
@@ -39,12 +39,12 @@
 (defn bootstrap [api-root concise-handlers & [opts]]
   (martian/bootstrap api-root concise-handlers (merge default-opts opts)))
 
-(defn bootstrap-openapi [url & [opts get-swagger-opts]]
+(defn bootstrap-openapi [url & [{:keys [server-url] :as opts} get-swagger-opts]]
   (let [definition @(http/get url
                               (merge {:as :text} get-swagger-opts)
                               (fn [{:keys [body]}] (json/decode body keyword)))
         {:keys [scheme server-name server-port]} (parse-url url)
-        api-root (or (:server-url opts) (openapi/base-url definition))
+        api-root (or server-url (openapi/base-url definition))
         base-url (if (and (openapi-schema? definition) (not (string/starts-with? api-root "/")))
                    api-root
                    (format "%s://%s%s%s" (name scheme) server-name (if server-port (str ":" server-port) "")

--- a/httpkit/src/martian/httpkit.clj
+++ b/httpkit/src/martian/httpkit.clj
@@ -2,20 +2,10 @@
   (:require [org.httpkit.client :as http]
             [martian.core :as martian]
             [martian.interceptors :as interceptors]
-            [martian.openapi :refer [openapi-schema?] :as openapi]
+            [martian.openapi :as openapi]
             [cheshire.core :as json]
-            [clojure.string :as string]
             [tripod.context :as tc])
   (:import [java.net URL]))
-
-(defn- parse-url
-  "Parse a URL string into a map of interesting parts. Lifted from clj-http."
-  [url]
-  (let [url-parsed (URL. url)]
-    {:scheme (keyword (.getProtocol url-parsed))
-     :server-name (.getHost url-parsed)
-     :server-port (let [port (.getPort url-parsed)]
-                    (when (pos? port) port))}))
 
 (def go-async interceptors/remove-stack)
 
@@ -43,15 +33,7 @@
   (let [definition @(http/get url
                               (merge {:as :text} get-swagger-opts)
                               (fn [{:keys [body]}] (json/decode body keyword)))
-        {:keys [scheme server-name server-port]} (parse-url url)
-        api-root (or server-url (openapi/base-url definition))
-        base-url (if (and (openapi-schema? definition) (not (string/starts-with? api-root "/")))
-                   api-root
-                   (str (name scheme) "://"
-                        server-name (when server-port (str ":" server-port))
-                        (if (openapi-schema? definition)
-                          api-root
-                          (get definition :basePath ""))))]
+        base-url (openapi/base-url url server-url definition)]
     (martian/bootstrap-openapi base-url definition (merge default-opts opts))))
 
 (def bootstrap-swagger bootstrap-openapi)

--- a/httpkit/src/martian/httpkit.clj
+++ b/httpkit/src/martian/httpkit.clj
@@ -47,10 +47,11 @@
         api-root (or server-url (openapi/base-url definition))
         base-url (if (and (openapi-schema? definition) (not (string/starts-with? api-root "/")))
                    api-root
-                   (format "%s://%s%s%s" (name scheme) server-name (if server-port (str ":" server-port) "")
-                           (if (openapi-schema? definition)
-                             api-root
-                             (get definition :basePath ""))))]
+                   (str (name scheme) "://"
+                        server-name (when server-port (str ":" server-port))
+                        (if (openapi-schema? definition)
+                          api-root
+                          (get definition :basePath ""))))]
     (martian/bootstrap-openapi base-url definition (merge default-opts opts))))
 
 (def bootstrap-swagger bootstrap-openapi)

--- a/httpkit/test/martian/httpkit_test.clj
+++ b/httpkit/test/martian/httpkit_test.clj
@@ -38,11 +38,18 @@
 
 (deftest openapi-bootstrap-test
   (let [m (martian-http/bootstrap-openapi openapi-url)
-        mt (martian-http/bootstrap-openapi openapi-test-url)]
+        mt (martian-http/bootstrap-openapi openapi-test-url)
+        mt1 (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"})
+        mt2 (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"})]
 
     (is (= "https://sandbox.example.com"
            (:api-root mt)) "check absolute server url")
 
+    (is (= "https://sandbox.com"
+           (:api-root mt1)) "check absolute server url via opts")
+
+    (is (= "http://localhost:8888/v3.1"
+           (:api-root mt2)) "check relative server url via opts")
 
     (is (= "http://localhost:8888/openapi/v3"
            (:api-root m)))

--- a/httpkit/test/martian/httpkit_test.clj
+++ b/httpkit/test/martian/httpkit_test.clj
@@ -37,19 +37,19 @@
              (:body response))))))
 
 (deftest openapi-bootstrap-test
-  (let [m (martian-http/bootstrap-openapi openapi-url)
-        mt (martian-http/bootstrap-openapi openapi-test-url)
-        mt1 (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"})
-        mt2 (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"})]
+  (let [m (martian-http/bootstrap-openapi openapi-url)]
 
     (is (= "https://sandbox.example.com"
-           (:api-root mt)) "check absolute server url")
+           (:api-root (martian-http/bootstrap-openapi openapi-test-url)))
+        "check absolute server url")
 
     (is (= "https://sandbox.com"
-           (:api-root mt1)) "check absolute server url via opts")
+           (:api-root (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"})))
+        "check absolute server url via opts")
 
     (is (= "http://localhost:8888/v3.1"
-           (:api-root mt2)) "check relative server url via opts")
+           (:api-root (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"})))
+        "check relative server url via opts")
 
     (is (= "http://localhost:8888/openapi/v3"
            (:api-root m)))

--- a/httpkit/test/martian/httpkit_test.clj
+++ b/httpkit/test/martian/httpkit_test.clj
@@ -1,7 +1,7 @@
 (ns martian.httpkit-test
   (:require [martian.httpkit :as martian-http]
             [martian.core :as martian]
-            [martian.server-stub :refer [with-server swagger-url openapi-url]]
+            [martian.server-stub :refer [with-server swagger-url openapi-url openapi-test-url]]
             [martian.encoders :as encoders]
             [martian.test-utils :refer [input-stream->byte-array]]
             [clojure.test :refer [deftest testing is use-fixtures]]))
@@ -37,7 +37,12 @@
              (:body response))))))
 
 (deftest openapi-bootstrap-test
-  (let [m (martian-http/bootstrap-openapi openapi-url)]
+  (let [m (martian-http/bootstrap-openapi openapi-url)
+        mt (martian-http/bootstrap-openapi openapi-test-url)]
+
+    (is (= "https://sandbox.example.com"
+           (:api-root mt)) "check absolute server url")
+
 
     (is (= "http://localhost:8888/openapi/v3"
            (:api-root m)))

--- a/test-common/martian/server_stub.clj
+++ b/test-common/martian/server_stub.clj
@@ -64,6 +64,7 @@
 
 (def swagger-url (format "http://localhost:%s/swagger.json" (::bootstrap/port service)))
 (def openapi-url (format "http://localhost:%s/openapi.json" (::bootstrap/port service)))
+(def openapi-test-url (format "http://localhost:%s/openapi-test.json" (::bootstrap/port service)))
 
 (def with-server
   (fn [f]

--- a/test-common/public/openapi-test.json
+++ b/test-common/public/openapi-test.json
@@ -1,0 +1,28 @@
+{"openapi": "3.1.0",
+ "info":
+ {"version": "1.2.3",
+  "title": "Repro",
+  "description": "A OAS 3.1.0 definition for testing."},
+ "paths":
+ {"/items":
+  {"get":
+   {"summary": "Gets a list of items.",
+    "description": "Filler",
+    "operationId": "list-items",
+    "parameters":
+    [{"in": "query",
+      "name": "ClientId",
+      "description": "Client identifier",
+      "schema": {"type": "string"},
+      "required": false}],
+    "responses":
+    {"200":
+     {"description": "Success.",
+      "content":
+      {"application/json":
+       {"schema":
+        {"type": "array",
+         "maxItems": 5000,
+         "items": {"type": "string"}}}}}}}}},
+ "servers":
+ [{"url": "https://sandbox.example.com", "description": "Sandbox"}]}


### PR DESCRIPTION
I believe this PR should address issue #116 .  At least for the CLJ clients.
Currently `openapi/base-url` picks the first server listed in the `servers` field.
To allow the selection of any server, I added the capability of providing a `:server-url` key in the `opts` parameter of `martian-http/bootstrap-openapi`.

I have made the changes to each CJ client and added tests for each of them.

I have not yet made the corresponding changes to the CLJS clients or added tests for them.
I am not sure how the tests for the CLJS clients are supposed to work. I ran `lein test` on the CLJ clients just fine.
Running `lein test` from the `cljs-http` directory results in
```
Syntax error (NoSuchMethodError) compiling at (figwheel/main.cljc:1:1).
'java.util.stream.Collector com.google.common.collect.ImmutableSortedSet.toImmutableSortedSet(java.util.Comparator)'
```
I'd appreciate any guidance on running tests for CLJS clients.
