### PR TITLE
Add support for the :plus-json option to bootstrap-openapi.

### DIFF
--- a/core/src/martian/openapi.cljc
+++ b/core/src/martian/openapi.cljc
@@ -148,7 +148,9 @@
           ;; which aren't the associated OPTIONS call.
           :when (and (:operationId definition)
                      (not= :options method))
-          :let [parameters (group-by (comp keyword :in) (concat common-parameters (:parameters definition)))
+          :let [parameters (group-by (comp keyword :in) (concat common-parameters
+                                                                (map (partial resolve-ref components)
+                                                                     (:parameters definition))))
                 body       (process-body (:requestBody definition) components (:encodes content-types))
                 responses  (process-responses (:responses definition) components (:decodes content-types))]]
       {:path-parts         (vec (tokenise-path url))


### PR DESCRIPTION
This adds encoders and decoders for all content types of the form
application/vnd.foo.bar+json that are found in the OpenAPI spec.

Should address #143 