### PR TITLE
Support date-time and int-or-string string formats

### DIFF
--- a/core/src/martian/schema.cljc
+++ b/core/src/martian/schema.cljc
@@ -85,6 +85,7 @@
     (= "string" type) (case format
                         "uuid" (s/cond-pre s/Str s/Uuid)
                         "uri" (s/cond-pre s/Str URI)
+                        "date-time" (s/cond-pre s/Str s/Inst)
                         s/Str)
     (= "integer" type) s/Int
     (= "number" type) s/Num

--- a/core/src/martian/schema.cljc
+++ b/core/src/martian/schema.cljc
@@ -86,6 +86,7 @@
                         "uuid" (s/cond-pre s/Str s/Uuid)
                         "uri" (s/cond-pre s/Str URI)
                         "date-time" (s/cond-pre s/Str s/Inst)
+                        "int-or-string" (s/cond-pre s/Str s/Int)
                         s/Str)
     (= "integer" type) s/Int
     (= "number" type) s/Num

--- a/core/test-resources/swagger.json
+++ b/core/test-resources/swagger.json
@@ -300,6 +300,10 @@
         "age": {
           "type": "integer",
           "format": "int64"
+        },
+        "adoptionTime": {
+          "type": "string",
+          "format": "date-time"
         }
       },
       "additionalProperties": false,
@@ -321,6 +325,10 @@
         "age": {
           "type": "integer",
           "format": "int64"
+        },
+        "adoptionTime": {
+          "type": "string",
+          "format": "date-time"
         },
         "id": {
           "type": "string",

--- a/core/test/martian/schema_test.cljc
+++ b/core/test/martian/schema_test.cljc
@@ -167,7 +167,13 @@
                                        :tags [{:k nil}]}
                                       nil
                                       true)))))))))
-
+(deftest date-time-test
+  (is (= (s/cond-pre s/Str s/Inst)
+         (schema/make-schema {:definitions {}} {:name "date-time"
+                                                :in "path"
+                                                :required true
+                                                :type "string"
+                                                :format "date-time"}))))
 (deftest uuid-test
   (is (= (s/cond-pre s/Str s/Uuid)
          (schema/make-schema {:definitions {}} {:name "uuid"

--- a/core/test/martian/schema_test.cljc
+++ b/core/test/martian/schema_test.cljc
@@ -167,6 +167,15 @@
                                        :tags [{:k nil}]}
                                       nil
                                       true)))))))))
+;; "int-or-string" (s/cond-pre s/Str s/Int)
+(deftest int-or-string-test
+  (is (= (s/cond-pre s/Str s/Int)
+         (schema/make-schema {:definitions {}} {:name "int-or-string"
+                                                :in "path"
+                                                :required true
+                                                :type "string"
+                                                :format "int-or-string"}))))
+
 (deftest date-time-test
   (is (= (s/cond-pre s/Str s/Inst)
          (schema/make-schema {:definitions {}} {:name "date-time"


### PR DESCRIPTION
These changes assist with using the Kubernetes API which makes use of date-time fields and has the concept of a int-or-string format. 

Without the int-or-string type - Martian gives a validation error when trying to use the ':port 8080' in a kubernetes readiness check complaining that a String is required. :port 8080 is a valid value as-is :port "https" and they have different meanings to Kubernetes.

I'm not sure if this specific use case makes sense for upstream and the tests for these enhancements could probably be expanded but I figured I'd submit this pull request just in case.