### PR TITLE
Fix no object properties

### DIFF
--- a/core/src/martian/openapi.cljc
+++ b/core/src/martian/openapi.cljc
@@ -72,13 +72,16 @@
                       (when (= #{:properties} (set (keys schema))) "object"))
              "array"   [(openapi->schema (:items schema) components seen-set)]
              "object"  (let [required? (set (:required schema))]
-                         (into {}
-                               (map (fn [[k v]]
-                                      {(if (required? (name k))
-                                         (keyword k)
-                                         (s/optional-key (keyword k)))
-                                       (openapi->schema v components seen-set)}))
-                               (:properties schema)))
+                         (if (or (contains? schema :properties)
+                                 (contains? schema :additionalProperties))
+                           (into {}
+                                 (map (fn [[k v]]
+                                        {(if (required? (name k))
+                                           (keyword k)
+                                           (s/optional-key (keyword k)))
+                                         (openapi->schema v components seen-set)}))
+                                 (:properties schema))
+                           {s/Any s/Any}))
              (leaf-schema schema))))))
 
 (defn- stringify-ns-keyword [k]

--- a/core/src/martian/schema.cljc
+++ b/core/src/martian/schema.cljc
@@ -122,8 +122,13 @@
        properties))
 
 (defn- make-object-schema [ref-lookup {:keys [additionalProperties] :as schema}]
-  (cond-> (schemas-for-parameters ref-lookup (denormalise-object-properties schema))
-    additionalProperties (assoc s/Any s/Any)))
+  ;; It's possible for an 'object' to omit properties and
+  ;; additionalProperties. If this is the case - anything is allowed.
+  (if (or (contains? schema :properties)
+          (contains? schema :additionalProperties))
+    (cond-> (schemas-for-parameters ref-lookup (denormalise-object-properties schema))
+      additionalProperties (assoc s/Any s/Any))
+    {s/Any s/Any}))
 
 (defn make-schema
   "Takes a swagger parameter and returns a schema"

--- a/core/test-resources/kubernetes-openapi-v3-converted.yaml
+++ b/core/test-resources/kubernetes-openapi-v3-converted.yaml
@@ -1,0 +1,987 @@
+# Converted from kubernetes-swagger-v2.json via https://mermade.org.uk/api/v1/convert
+openapi: 3.0.0
+info:
+  title: Kubernetes
+  version: v1.23.10
+paths:
+  "/api/v1/namespaces/{namespace}/secrets/{name}":
+    get:
+      description: read the specified Secret
+      tags:
+        - core_v1
+      operationId: readCoreV1NamespacedSecret
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/io.k8s.api.core.v1.Secret"
+            application/yaml:
+              schema:
+                $ref: "#/components/schemas/io.k8s.api.core.v1.Secret"
+            application/vnd.kubernetes.protobuf:
+              schema:
+                $ref: "#/components/schemas/io.k8s.api.core.v1.Secret"
+        "401":
+          description: Unauthorized
+      x-kubernetes-action: get
+      x-kubernetes-group-version-kind:
+        group: ""
+        kind: Secret
+        version: v1
+      servers: []
+    put:
+      description: replace the specified Secret
+      tags:
+        - core_v1
+      operationId: replaceCoreV1NamespacedSecret
+      parameters:
+        - description: "When present, indicates that modifications should not be persisted.
+            An invalid or unrecognized dryRun directive will result in an error
+            response and no further processing of the request. Valid values are:
+            - All: all dry run stages will be processed"
+          name: dryRun
+          in: query
+          schema:
+            type: string
+            uniqueItems: true
+        - description: fieldManager is a name associated with the actor or entity that is
+            making these changes. The value must be less than or 128 characters
+            long, and only contain printable characters, as defined by
+            https://golang.org/pkg/unicode/#IsPrint.
+          name: fieldManager
+          in: query
+          schema:
+            type: string
+            uniqueItems: true
+      requestBody:
+        content:
+          "*/*":
+            schema:
+              $ref: "#/components/schemas/io.k8s.api.core.v1.Secret"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/io.k8s.api.core.v1.Secret"
+            application/yaml:
+              schema:
+                $ref: "#/components/schemas/io.k8s.api.core.v1.Secret"
+            application/vnd.kubernetes.protobuf:
+              schema:
+                $ref: "#/components/schemas/io.k8s.api.core.v1.Secret"
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/io.k8s.api.core.v1.Secret"
+            application/yaml:
+              schema:
+                $ref: "#/components/schemas/io.k8s.api.core.v1.Secret"
+            application/vnd.kubernetes.protobuf:
+              schema:
+                $ref: "#/components/schemas/io.k8s.api.core.v1.Secret"
+        "401":
+          description: Unauthorized
+      x-kubernetes-action: put
+      x-kubernetes-group-version-kind:
+        group: ""
+        kind: Secret
+        version: v1
+      servers: []
+    delete:
+      description: delete a Secret
+      tags:
+        - core_v1
+      operationId: deleteCoreV1NamespacedSecret
+      parameters:
+        - description: "When present, indicates that modifications should not be persisted.
+            An invalid or unrecognized dryRun directive will result in an error
+            response and no further processing of the request. Valid values are:
+            - All: all dry run stages will be processed"
+          name: dryRun
+          in: query
+          schema:
+            type: string
+            uniqueItems: true
+        - description: The duration in seconds before the object should be deleted. Value
+            must be non-negative integer. The value zero indicates delete
+            immediately. If this value is nil, the default grace period for the
+            specified type will be used. Defaults to a per object value if not
+            specified. zero means delete immediately.
+          name: gracePeriodSeconds
+          in: query
+          schema:
+            type: integer
+            uniqueItems: true
+        - description: "Deprecated: please use the PropagationPolicy, this field will be
+            deprecated in 1.7. Should the dependent objects be orphaned. If
+            true/false, the \"orphan\" finalizer will be added to/removed from
+            the object's finalizers list. Either this field or PropagationPolicy
+            may be set, but not both."
+          name: orphanDependents
+          in: query
+          schema:
+            type: boolean
+            uniqueItems: true
+        - description: "Whether and how garbage collection will be performed. Either this
+            field or OrphanDependents may be set, but not both. The default
+            policy is decided by the existing finalizer set in the
+            metadata.finalizers and the resource-specific default policy.
+            Acceptable values are: 'Orphan' - orphan the dependents;
+            'Background' - allow the garbage collector to delete the dependents
+            in the background; 'Foreground' - a cascading policy that deletes
+            all dependents in the foreground."
+          name: propagationPolicy
+          in: query
+          schema:
+            type: string
+            uniqueItems: true
+      requestBody:
+        content:
+          "*/*":
+            schema:
+              $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Dele\
+                teOptions"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.St\
+                  atus"
+            application/yaml:
+              schema:
+                $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.St\
+                  atus"
+            application/vnd.kubernetes.protobuf:
+              schema:
+                $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.St\
+                  atus"
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.St\
+                  atus"
+            application/yaml:
+              schema:
+                $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.St\
+                  atus"
+            application/vnd.kubernetes.protobuf:
+              schema:
+                $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.St\
+                  atus"
+        "401":
+          description: Unauthorized
+      x-kubernetes-action: delete
+      x-kubernetes-group-version-kind:
+        group: ""
+        kind: Secret
+        version: v1
+      servers: []
+    patch:
+      description: partially update the specified Secret
+      tags:
+        - core_v1
+      operationId: patchCoreV1NamespacedSecret
+      parameters:
+        - description: "When present, indicates that modifications should not be persisted.
+            An invalid or unrecognized dryRun directive will result in an error
+            response and no further processing of the request. Valid values are:
+            - All: all dry run stages will be processed"
+          name: dryRun
+          in: query
+          schema:
+            type: string
+            uniqueItems: true
+        - description: fieldManager is a name associated with the actor or entity that is
+            making these changes. The value must be less than or 128 characters
+            long, and only contain printable characters, as defined by
+            https://golang.org/pkg/unicode/#IsPrint. This field is required for
+            apply requests (application/apply-patch) but optional for non-apply
+            patch types (JsonPatch, MergePatch, StrategicMergePatch).
+          name: fieldManager
+          in: query
+          schema:
+            type: string
+            uniqueItems: true
+        - description: Force is going to "force" Apply requests. It means user will
+            re-acquire conflicting fields owned by other people. Force flag must
+            be unset for non-apply patch requests.
+          name: force
+          in: query
+          schema:
+            type: boolean
+            uniqueItems: true
+      requestBody:
+        content:
+          application/json-patch+json:
+            schema:
+              $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+          application/merge-patch+json:
+            schema:
+              $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+          application/strategic-merge-patch+json:
+            schema:
+              $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+          application/apply-patch+yaml:
+            schema:
+              $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/io.k8s.api.core.v1.Secret"
+            application/yaml:
+              schema:
+                $ref: "#/components/schemas/io.k8s.api.core.v1.Secret"
+            application/vnd.kubernetes.protobuf:
+              schema:
+                $ref: "#/components/schemas/io.k8s.api.core.v1.Secret"
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/io.k8s.api.core.v1.Secret"
+            application/yaml:
+              schema:
+                $ref: "#/components/schemas/io.k8s.api.core.v1.Secret"
+            application/vnd.kubernetes.protobuf:
+              schema:
+                $ref: "#/components/schemas/io.k8s.api.core.v1.Secret"
+        "401":
+          description: Unauthorized
+      x-kubernetes-action: patch
+      x-kubernetes-group-version-kind:
+        group: ""
+        kind: Secret
+        version: v1
+      servers: []
+    parameters:
+      - description: name of the Secret
+        name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          uniqueItems: true
+      - description: object name and auth scope, such as for teams and projects
+        name: namespace
+        in: path
+        required: true
+        schema:
+          type: string
+          uniqueItems: true
+      - description: If 'true', then the output is pretty printed.
+        name: pretty
+        in: query
+        schema:
+          type: string
+          uniqueItems: true
+security:
+  - BearerToken: []
+components:
+  securitySchemes:
+    BearerToken:
+      description: Bearer Token authentication
+      type: apiKey
+      name: authorization
+      in: header
+  schemas:
+    io.k8s.api.core.v1.Secret:
+      description: Secret holds secret data of a certain type. The total bytes of the
+        values in the Data field must be less than MaxSecretSize bytes.
+      type: object
+      properties:
+        apiVersion:
+          description: "APIVersion defines the versioned schema of this representation of
+            an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/ap\
+            i-conventions.md#resources"
+          type: string
+        data:
+          description: Data contains the secret data. Each key must consist of alphanumeric
+            characters, '-', '_' or '.'. The serialized form of the secret data
+            is a base64 encoded string, representing the arbitrary (possibly
+            non-string) data value here. Described in
+            https://tools.ietf.org/html/rfc4648#section-4
+          type: object
+          additionalProperties:
+            type: string
+            format: byte
+        immutable:
+          description: Immutable, if set to true, ensures that data stored in the Secret
+            cannot be updated (only object metadata can be modified). If not set
+            to true, the field can be modified at any time. Defaulted to nil.
+          type: boolean
+        kind:
+          description: "Kind is a string value representing the REST resource this object
+            represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/ap\
+            i-conventions.md#types-kinds"
+          type: string
+        metadata:
+          $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMe\
+            ta"
+        stringData:
+          description: stringData allows specifying non-binary secret data in string form.
+            It is provided as a write-only input field for convenience. All keys
+            and values are merged into the data field on write, overwriting any
+            existing values. The stringData field is never output when reading
+            from the API.
+          type: object
+          additionalProperties:
+            type: string
+        type:
+          description: "Used to facilitate programmatic handling of secret data. More info:
+            https://kubernetes.io/docs/concepts/configuration/secret/#secret-ty\
+            pes"
+          type: string
+      x-kubernetes-group-version-kind:
+        - group: ""
+          kind: Secret
+          version: v1
+    io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions:
+      description: DeleteOptions may be provided when deleting an API object.
+      type: object
+      properties:
+        apiVersion:
+          description: "APIVersion defines the versioned schema of this representation of
+            an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/ap\
+            i-conventions.md#resources"
+          type: string
+        dryRun:
+          description: "When present, indicates that modifications should not be persisted.
+            An invalid or unrecognized dryRun directive will result in an error
+            response and no further processing of the request. Valid values are:
+            - All: all dry run stages will be processed"
+          type: array
+          items:
+            type: string
+        gracePeriodSeconds:
+          description: The duration in seconds before the object should be deleted. Value
+            must be non-negative integer. The value zero indicates delete
+            immediately. If this value is nil, the default grace period for the
+            specified type will be used. Defaults to a per object value if not
+            specified. zero means delete immediately.
+          type: integer
+          format: int64
+        kind:
+          description: "Kind is a string value representing the REST resource this object
+            represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/ap\
+            i-conventions.md#types-kinds"
+          type: string
+        orphanDependents:
+          description: "Deprecated: please use the PropagationPolicy, this field will be
+            deprecated in 1.7. Should the dependent objects be orphaned. If
+            true/false, the \"orphan\" finalizer will be added to/removed from
+            the object's finalizers list. Either this field or PropagationPolicy
+            may be set, but not both."
+          type: boolean
+        preconditions:
+          $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Precondi\
+            tions"
+        propagationPolicy:
+          description: "Whether and how garbage collection will be performed. Either this
+            field or OrphanDependents may be set, but not both. The default
+            policy is decided by the existing finalizer set in the
+            metadata.finalizers and the resource-specific default policy.
+            Acceptable values are: 'Orphan' - orphan the dependents;
+            'Background' - allow the garbage collector to delete the dependents
+            in the background; 'Foreground' - a cascading policy that deletes
+            all dependents in the foreground."
+          type: string
+      x-kubernetes-group-version-kind:
+        - group: ""
+          kind: DeleteOptions
+          version: v1
+        - group: admission.k8s.io
+          kind: DeleteOptions
+          version: v1
+        - group: admission.k8s.io
+          kind: DeleteOptions
+          version: v1beta1
+        - group: admissionregistration.k8s.io
+          kind: DeleteOptions
+          version: v1
+        - group: admissionregistration.k8s.io
+          kind: DeleteOptions
+          version: v1beta1
+        - group: apiextensions.k8s.io
+          kind: DeleteOptions
+          version: v1
+        - group: apiextensions.k8s.io
+          kind: DeleteOptions
+          version: v1beta1
+        - group: apiregistration.k8s.io
+          kind: DeleteOptions
+          version: v1
+        - group: apiregistration.k8s.io
+          kind: DeleteOptions
+          version: v1beta1
+        - group: apps
+          kind: DeleteOptions
+          version: v1
+        - group: apps
+          kind: DeleteOptions
+          version: v1beta1
+        - group: apps
+          kind: DeleteOptions
+          version: v1beta2
+        - group: authentication.k8s.io
+          kind: DeleteOptions
+          version: v1
+        - group: authentication.k8s.io
+          kind: DeleteOptions
+          version: v1beta1
+        - group: authorization.k8s.io
+          kind: DeleteOptions
+          version: v1
+        - group: authorization.k8s.io
+          kind: DeleteOptions
+          version: v1beta1
+        - group: autoscaling
+          kind: DeleteOptions
+          version: v1
+        - group: autoscaling
+          kind: DeleteOptions
+          version: v2
+        - group: autoscaling
+          kind: DeleteOptions
+          version: v2beta1
+        - group: autoscaling
+          kind: DeleteOptions
+          version: v2beta2
+        - group: batch
+          kind: DeleteOptions
+          version: v1
+        - group: batch
+          kind: DeleteOptions
+          version: v1beta1
+        - group: certificates.k8s.io
+          kind: DeleteOptions
+          version: v1
+        - group: certificates.k8s.io
+          kind: DeleteOptions
+          version: v1beta1
+        - group: coordination.k8s.io
+          kind: DeleteOptions
+          version: v1
+        - group: coordination.k8s.io
+          kind: DeleteOptions
+          version: v1beta1
+        - group: discovery.k8s.io
+          kind: DeleteOptions
+          version: v1
+        - group: discovery.k8s.io
+          kind: DeleteOptions
+          version: v1beta1
+        - group: events.k8s.io
+          kind: DeleteOptions
+          version: v1
+        - group: events.k8s.io
+          kind: DeleteOptions
+          version: v1beta1
+        - group: extensions
+          kind: DeleteOptions
+          version: v1beta1
+        - group: flowcontrol.apiserver.k8s.io
+          kind: DeleteOptions
+          version: v1alpha1
+        - group: flowcontrol.apiserver.k8s.io
+          kind: DeleteOptions
+          version: v1beta1
+        - group: flowcontrol.apiserver.k8s.io
+          kind: DeleteOptions
+          version: v1beta2
+        - group: imagepolicy.k8s.io
+          kind: DeleteOptions
+          version: v1alpha1
+        - group: internal.apiserver.k8s.io
+          kind: DeleteOptions
+          version: v1alpha1
+        - group: networking.k8s.io
+          kind: DeleteOptions
+          version: v1
+        - group: networking.k8s.io
+          kind: DeleteOptions
+          version: v1beta1
+        - group: node.k8s.io
+          kind: DeleteOptions
+          version: v1
+        - group: node.k8s.io
+          kind: DeleteOptions
+          version: v1alpha1
+        - group: node.k8s.io
+          kind: DeleteOptions
+          version: v1beta1
+        - group: policy
+          kind: DeleteOptions
+          version: v1
+        - group: policy
+          kind: DeleteOptions
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: DeleteOptions
+          version: v1
+        - group: rbac.authorization.k8s.io
+          kind: DeleteOptions
+          version: v1alpha1
+        - group: rbac.authorization.k8s.io
+          kind: DeleteOptions
+          version: v1beta1
+        - group: scheduling.k8s.io
+          kind: DeleteOptions
+          version: v1
+        - group: scheduling.k8s.io
+          kind: DeleteOptions
+          version: v1alpha1
+        - group: scheduling.k8s.io
+          kind: DeleteOptions
+          version: v1beta1
+        - group: storage.k8s.io
+          kind: DeleteOptions
+          version: v1
+        - group: storage.k8s.io
+          kind: DeleteOptions
+          version: v1alpha1
+        - group: storage.k8s.io
+          kind: DeleteOptions
+          version: v1beta1
+    io.k8s.apimachinery.pkg.apis.meta.v1.Status:
+      description: Status is a return value for calls that don't return other objects.
+      type: object
+      properties:
+        apiVersion:
+          description: "APIVersion defines the versioned schema of this representation of
+            an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/ap\
+            i-conventions.md#resources"
+          type: string
+        code:
+          description: Suggested HTTP return code for this status, 0 if not set.
+          type: integer
+          format: int32
+        details:
+          $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDe\
+            tails"
+        kind:
+          description: "Kind is a string value representing the REST resource this object
+            represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/ap\
+            i-conventions.md#types-kinds"
+          type: string
+        message:
+          description: A human-readable description of the status of this operation.
+          type: string
+        metadata:
+          $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+        reason:
+          description: A machine-readable description of why this operation is in the
+            "Failure" status. If this value is empty there is no information
+            available. A Reason clarifies an HTTP status code but does not
+            override it.
+          type: string
+        status:
+          description: 'Status of the operation. One of: "Success" or "Failure". More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          type: string
+      x-kubernetes-group-version-kind:
+        - group: ""
+          kind: Status
+          version: v1
+    io.k8s.apimachinery.pkg.apis.meta.v1.Patch:
+      description: Patch is provided to give a concrete name and type to the Kubernetes
+        PATCH request body.
+      type: object
+    io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta:
+      description: ObjectMeta is metadata that all persisted resources must have, which
+        includes all objects users must create.
+      type: object
+      properties:
+        annotations:
+          description: "Annotations is an unstructured key value map stored with a resource
+            that may be set by external tools to store and retrieve arbitrary
+            metadata. They are not queryable and should be preserved when
+            modifying objects. More info:
+            http://kubernetes.io/docs/user-guide/annotations"
+          type: object
+          additionalProperties:
+            type: string
+        clusterName:
+          description: The name of the cluster which the object belongs to. This is used to
+            distinguish resources with same name and namespace in different
+            clusters. This field is not set anywhere right now and apiserver is
+            going to ignore it if set in create or update request.
+          type: string
+        creationTimestamp:
+          $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        deletionGracePeriodSeconds:
+          description: Number of seconds allowed for this object to gracefully terminate
+            before it will be removed from the system. Only set when
+            deletionTimestamp is also set. May only be shortened. Read-only.
+          type: integer
+          format: int64
+        deletionTimestamp:
+          $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        finalizers:
+          description: Must be empty before the object is deleted from the registry. Each
+            entry is an identifier for the responsible component that will
+            remove the entry from the list. If the deletionTimestamp of the
+            object is non-nil, entries in this list can only be removed.
+            Finalizers may be processed and removed in any order.  Order is NOT
+            enforced because it introduces significant risk of stuck finalizers.
+            finalizers is a shared field, any actor with permission can reorder
+            it. If the finalizer list is processed in order, then this can lead
+            to a situation in which the component responsible for the first
+            finalizer in the list is waiting for a signal (field value, external
+            system, or other) produced by a component responsible for a
+            finalizer later in the list, resulting in a deadlock. Without
+            enforced ordering finalizers are free to order amongst themselves
+            and are not vulnerable to ordering changes in the list.
+          type: array
+          items:
+            type: string
+          x-kubernetes-patch-strategy: merge
+        generateName:
+          description: >-
+            GenerateName is an optional prefix, used by the server, to generate
+            a unique name ONLY IF the Name field has not been provided. If this
+            field is used, the name returned to the client will be different
+            than the name passed. This value will also be combined with a unique
+            suffix. The provided value has the same validation rules as the Name
+            field, and may be truncated by the length of the suffix required to
+            make the value unique on the server.
+
+
+            If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+
+            Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+          type: string
+        generation:
+          description: A sequence number representing a specific generation of the desired
+            state. Populated by the system. Read-only.
+          type: integer
+          format: int64
+        labels:
+          description: "Map of string keys and values that can be used to organize and
+            categorize (scope and select) objects. May match selectors of
+            replication controllers and services. More info:
+            http://kubernetes.io/docs/user-guide/labels"
+          type: object
+          additionalProperties:
+            type: string
+        managedFields:
+          description: ManagedFields maps workflow-id and version to the set of fields that
+            are managed by that workflow. This is mostly for internal
+            housekeeping, and users typically shouldn't need to set or
+            understand this field. A workflow can be the user's name, a
+            controller's name, or the name of a specific apply path like
+            "ci-cd". The set of fields is always in the version that the
+            workflow used when modifying the object.
+          type: array
+          items:
+            $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Manage\
+              dFieldsEntry"
+        name:
+          description: "Name must be unique within a namespace. Is required when creating
+            resources, although some resources may allow a client to request the
+            generation of an appropriate name automatically. Name is primarily
+            intended for creation idempotence and configuration definition.
+            Cannot be updated. More info:
+            http://kubernetes.io/docs/user-guide/identifiers#names"
+          type: string
+        namespace:
+          description: >-
+            Namespace defines the space within which each name must be unique.
+            An empty namespace is equivalent to the "default" namespace, but
+            "default" is the canonical representation. Not all objects are
+            required to be scoped to a namespace - the value of this field for
+            those objects will be empty.
+
+
+            Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+          type: string
+        ownerReferences:
+          description: List of objects depended by this object. If ALL objects in the list
+            have been deleted, this object will be garbage collected. If this
+            object is managed by a controller, then an entry in this list will
+            point to this controller, with the controller field set to true.
+            There cannot be more than one managing controller.
+          type: array
+          items:
+            $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerR\
+              eference"
+          x-kubernetes-patch-merge-key: uid
+          x-kubernetes-patch-strategy: merge
+        resourceVersion:
+          description: >-
+            An opaque value that represents the internal version of this object
+            that can be used by clients to determine when objects have changed.
+            May be used for optimistic concurrency, change detection, and the
+            watch operation on a resource or set of resources. Clients must
+            treat these values as opaque and passed unmodified back to the
+            server. They may only be valid for a particular resource or set of
+            resources.
+
+
+            Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+          type: string
+        selfLink:
+          description: >-
+            SelfLink is a URL representing this object. Populated by the system.
+            Read-only.
+
+
+            DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+          type: string
+        uid:
+          description: >-
+            UID is the unique in time and space value for this object. It is
+            typically generated by the server on successful creation of a
+            resource and is not allowed to change on PUT operations.
+
+
+            Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+          type: string
+    io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions:
+      description: Preconditions must be fulfilled before an operation (update, delete,
+        etc.) is carried out.
+      type: object
+      properties:
+        resourceVersion:
+          description: Specifies the target ResourceVersion
+          type: string
+        uid:
+          description: Specifies the target UID.
+          type: string
+    io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails:
+      description: StatusDetails is a set of additional properties that MAY be set by the
+        server to provide additional information about a response. The Reason
+        field of a Status object defines what attributes will be set. Clients
+        must ignore fields that do not match the defined type of each attribute,
+        and should assume that any attribute may be empty, invalid, or under
+        defined.
+      type: object
+      properties:
+        causes:
+          description: The Causes array includes more details associated with the
+            StatusReason failure. Not all StatusReasons may provide detailed
+            causes.
+          type: array
+          items:
+            $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status\
+              Cause"
+        group:
+          description: The group attribute of the resource associated with the status
+            StatusReason.
+          type: string
+        kind:
+          description: "The kind attribute of the resource associated with the status
+            StatusReason. On some operations may differ from the requested
+            resource Kind. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/ap\
+            i-conventions.md#types-kinds"
+          type: string
+        name:
+          description: The name attribute of the resource associated with the status
+            StatusReason (when there is a single name which can be described).
+          type: string
+        retryAfterSeconds:
+          description: If specified, the time in seconds before the operation should be
+            retried. Some errors may indicate the client must take an alternate
+            action - for those errors this field may indicate how long to wait
+            before taking the alternate action.
+          type: integer
+          format: int32
+        uid:
+          description: "UID of the resource. (when there is a single resource which can be
+            described). More info:
+            http://kubernetes.io/docs/user-guide/identifiers#uids"
+          type: string
+    io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta:
+      description: ListMeta describes metadata that synthetic resources must have,
+        including lists and various status objects. A resource may have only one
+        of {ObjectMeta, ListMeta}.
+      type: object
+      properties:
+        continue:
+          description: continue may be set if the user set a limit on the number of items
+            returned, and indicates that the server has more data available. The
+            value is opaque and may be used to issue another request to the
+            endpoint that served this list to retrieve the next set of available
+            objects. Continuing a consistent list may not be possible if the
+            server configuration has changed or more than a few minutes have
+            passed. The resourceVersion field returned when using this continue
+            value will be identical to the value in the first response, unless
+            you have received this token from an error message.
+          type: string
+        remainingItemCount:
+          description: remainingItemCount is the number of subsequent items in the list
+            which are not included in this list response. If the list request
+            contained label or field selectors, then the number of remaining
+            items is unknown and the field will be left unset and omitted during
+            serialization. If the list is complete (either because it is not
+            chunking or because this is the last chunk), then there are no more
+            remaining items and this field will be left unset and omitted during
+            serialization. Servers older than v1.15 do not set this field. The
+            intended use of the remainingItemCount is *estimating* the size of a
+            collection. Clients should not rely on the remainingItemCount to be
+            set or to be exact.
+          type: integer
+          format: int64
+        resourceVersion:
+          description: "String that identifies the server's internal version of this object
+            that can be used by clients to determine when objects have changed.
+            Value must be treated as opaque by clients and passed unmodified
+            back to the server. Populated by the system. Read-only. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/ap\
+            i-conventions.md#concurrency-control-and-consistency"
+          type: string
+        selfLink:
+          description: >-
+            selfLink is a URL representing this object. Populated by the system.
+            Read-only.
+
+
+            DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+          type: string
+    io.k8s.apimachinery.pkg.apis.meta.v1.Time:
+      description: Time is a wrapper around time.Time which supports correct marshaling to
+        YAML and JSON.  Wrappers are provided for many of the factory methods
+        that the time package offers.
+      type: string
+      format: date-time
+    io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry:
+      description: ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of
+        the resource that the fieldset applies to.
+      type: object
+      properties:
+        apiVersion:
+          description: APIVersion defines the version of this resource that this field set
+            applies to. The format is "group/version" just like the top-level
+            APIVersion field. It is necessary to track the version of a field
+            set because it cannot be automatically converted.
+          type: string
+        fieldsType:
+          description: 'FieldsType is the discriminator for the different fields format and
+            version. There is currently only one possible value: "FieldsV1"'
+          type: string
+        fieldsV1:
+          $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1"
+        manager:
+          description: Manager is an identifier of the workflow managing these fields.
+          type: string
+        operation:
+          description: Operation is the type of operation which lead to this
+            ManagedFieldsEntry being created. The only valid values for this
+            field are 'Apply' and 'Update'.
+          type: string
+        subresource:
+          description: Subresource is the name of the subresource used to update that
+            object, or empty string if the object was updated through the main
+            resource. The value of this field is used to distinguish between
+            managers, even if they share the same name. For example, a status
+            update will be distinct from a regular update using the same manager
+            name. Note that the APIVersion field is not related to the
+            Subresource field and it always corresponds to the version of the
+            main resource.
+          type: string
+        time:
+          $ref: "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+    io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1:
+      description: >-
+        FieldsV1 stores a set of fields in a data structure like a Trie, in JSON
+        format.
+
+
+        Each key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:', where  is the name of a field in a struct, or key in a map 'v:', where  is the exact json formatted value of a list item 'i:', where  is position of a item in a list 'k:', where  is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.
+
+
+        The exact format is defined in sigs.k8s.io/structured-merge-diff
+      type: object
+    io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference:
+      description: OwnerReference contains enough information to let you identify an owning
+        object. An owning object must be in the same namespace as the dependent,
+        or be cluster-scoped, so there is no namespace field.
+      type: object
+      required:
+        - apiVersion
+        - kind
+        - name
+        - uid
+      properties:
+        apiVersion:
+          description: API version of the referent.
+          type: string
+        blockOwnerDeletion:
+          description: If true, AND if the owner has the "foregroundDeletion" finalizer,
+            then the owner cannot be deleted from the key-value store until this
+            reference is removed. Defaults to false. To set this field, a user
+            needs "delete" permission of the owner, otherwise 422 (Unprocessable
+            Entity) will be returned.
+          type: boolean
+        controller:
+          description: If true, this reference points to the managing controller.
+          type: boolean
+        kind:
+          description: "Kind of the referent. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/ap\
+            i-conventions.md#types-kinds"
+          type: string
+        name:
+          description: "Name of the referent. More info:
+            http://kubernetes.io/docs/user-guide/identifiers#names"
+          type: string
+        uid:
+          description: "UID of the referent. More info:
+            http://kubernetes.io/docs/user-guide/identifiers#uids"
+          type: string
+      x-kubernetes-map-type: atomic
+    io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause:
+      description: StatusCause provides more information about an api.Status failure,
+        including cases when multiple errors are encountered.
+      type: object
+      properties:
+        field:
+          description: >-
+            The field of the resource that has caused this error, as named by
+            its JSON serialization. May include dot and postfix notation for
+            nested attributes. Arrays are zero-indexed.  Fields may appear more
+            than once in an array of causes due to fields having multiple
+            errors. Optional.
+
+
+            Examples:
+              "name" - the field "name" on the current resource
+              "items[0].name" - the field "name" on the first array entry in "items"
+          type: string
+        message:
+          description: A human-readable description of the cause of the error.  This field
+            may be presented as-is to a reader.
+          type: string
+        reason:
+          description: A machine-readable description of the cause of the error. If this
+            value is empty there is no information available.
+          type: string

--- a/core/test-resources/kubernetes-swagger-v2.json
+++ b/core/test-resources/kubernetes-swagger-v2.json
@@ -685,6 +685,265 @@
     "io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
       "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
       "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+      "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "clusterName": {
+          "description": "The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.",
+          "type": "string"
+        },
+        "creationTimestamp": {
+          "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        },
+        "deletionGracePeriodSeconds": {
+          "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "deletionTimestamp": {
+          "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        },
+        "finalizers": {
+          "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "generateName": {
+          "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+          "type": "string"
+        },
+        "generation": {
+          "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "labels": {
+          "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "managedFields": {
+          "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
+          }
+        },
+        "name": {
+          "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+          "type": "string"
+        },
+        "ownerReferences": {
+          "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
+          },
+          "x-kubernetes-patch-merge-key": "uid",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "resourceVersion": {
+          "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+          "type": "string"
+        },
+        "selfLink": {
+          "description": "SelfLink is a URL representing this object. Populated by the system. Read-only.\n\nDEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.",
+          "type": "string"
+        },
+        "uid": {
+          "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+          "type": "string"
+        }
+      }
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions": {
+      "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
+      "type": "object",
+      "properties": {
+        "resourceVersion": {
+          "description": "Specifies the target ResourceVersion",
+          "type": "string"
+        },
+        "uid": {
+          "description": "Specifies the target UID.",
+          "type": "string"
+        }
+      }
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+      "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+      "type": "object",
+      "properties": {
+        "causes": {
+          "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause"
+          }
+        },
+        "group": {
+          "description": "The group attribute of the resource associated with the status StatusReason.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+          "type": "string"
+        },
+        "retryAfterSeconds": {
+          "description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "uid": {
+          "description": "UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+          "type": "string"
+        }
+      }
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
+      "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+      "type": "object",
+      "properties": {
+        "continue": {
+          "description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
+          "type": "string"
+        },
+        "remainingItemCount": {
+          "description": "remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "resourceVersion": {
+          "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+          "type": "string"
+        },
+        "selfLink": {
+          "description": "selfLink is a URL representing this object. Populated by the system. Read-only.\n\nDEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.",
+          "type": "string"
+        }
+      }
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+      "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": {
+      "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+          "type": "string"
+        },
+        "fieldsType": {
+          "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+          "type": "string"
+        },
+        "fieldsV1": {
+          "description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type.",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1"
+        },
+        "manager": {
+          "description": "Manager is an identifier of the workflow managing these fields.",
+          "type": "string"
+        },
+        "operation": {
+          "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+          "type": "string"
+        },
+        "subresource": {
+          "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+          "type": "string"
+        },
+        "time": {
+          "description": "Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+        }
+      }
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
+      "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+      "type": "object"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
+      "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+      "type": "object",
+      "required": [
+        "apiVersion",
+        "kind",
+        "name",
+        "uid"
+      ],
+      "properties": {
+        "apiVersion": {
+          "description": "API version of the referent.",
+          "type": "string"
+        },
+        "blockOwnerDeletion": {
+          "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+          "type": "boolean"
+        },
+        "controller": {
+          "description": "If true, this reference points to the managing controller.",
+          "type": "boolean"
+        },
+        "kind": {
+          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+          "type": "string"
+        },
+        "uid": {
+          "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+          "type": "string"
+        }
+      },
+      "x-kubernetes-map-type": "atomic"
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause": {
+      "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+      "type": "object",
+      "properties": {
+        "field": {
+          "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+          "type": "string"
+        },
+        "message": {
+          "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+          "type": "string"
+        }
+      }
     }
 
   },

--- a/core/test-resources/kubernetes-swagger-v2.json
+++ b/core/test-resources/kubernetes-swagger-v2.json
@@ -1,0 +1,704 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Kubernetes",
+    "version": "v1.23.10"
+  },
+  "paths": {
+    "/api/v1/namespaces/{namespace}/secrets/{name}": {
+      "get": {
+        "description": "read the specified Secret",
+        "consumes": [
+          "*/*"
+        ],
+        "produces": [
+          "application/json",
+          "application/yaml",
+          "application/vnd.kubernetes.protobuf"
+        ],
+        "schemes": [
+          "https"
+        ],
+        "tags": [
+          "core_v1"
+        ],
+        "operationId": "readCoreV1NamespacedSecret",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/io.k8s.api.core.v1.Secret"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "x-kubernetes-action": "get",
+        "x-kubernetes-group-version-kind": {
+          "group": "",
+          "kind": "Secret",
+          "version": "v1"
+        }
+      },
+      "put": {
+        "description": "replace the specified Secret",
+        "consumes": [
+          "*/*"
+        ],
+        "produces": [
+          "application/json",
+          "application/yaml",
+          "application/vnd.kubernetes.protobuf"
+        ],
+        "schemes": [
+          "https"
+        ],
+        "tags": [
+          "core_v1"
+        ],
+        "operationId": "replaceCoreV1NamespacedSecret",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/io.k8s.api.core.v1.Secret"
+            }
+          },
+          {
+            "uniqueItems": true,
+            "type": "string",
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "name": "dryRun",
+            "in": "query"
+          },
+          {
+            "uniqueItems": true,
+            "type": "string",
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+            "name": "fieldManager",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/io.k8s.api.core.v1.Secret"
+            }
+          },
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/io.k8s.api.core.v1.Secret"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "x-kubernetes-action": "put",
+        "x-kubernetes-group-version-kind": {
+          "group": "",
+          "kind": "Secret",
+          "version": "v1"
+        }
+      },
+      "delete": {
+        "description": "delete a Secret",
+        "consumes": [
+          "*/*"
+        ],
+        "produces": [
+          "application/json",
+          "application/yaml",
+          "application/vnd.kubernetes.protobuf"
+        ],
+        "schemes": [
+          "https"
+        ],
+        "tags": [
+          "core_v1"
+        ],
+        "operationId": "deleteCoreV1NamespacedSecret",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions"
+            }
+          },
+          {
+            "uniqueItems": true,
+            "type": "string",
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "name": "dryRun",
+            "in": "query"
+          },
+          {
+            "uniqueItems": true,
+            "type": "integer",
+            "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+            "name": "gracePeriodSeconds",
+            "in": "query"
+          },
+          {
+            "uniqueItems": true,
+            "type": "boolean",
+            "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+            "name": "orphanDependents",
+            "in": "query"
+          },
+          {
+            "uniqueItems": true,
+            "type": "string",
+            "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+            "name": "propagationPolicy",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+            }
+          },
+          "202": {
+            "description": "Accepted",
+            "schema": {
+              "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "x-kubernetes-action": "delete",
+        "x-kubernetes-group-version-kind": {
+          "group": "",
+          "kind": "Secret",
+          "version": "v1"
+        }
+      },
+      "patch": {
+        "description": "partially update the specified Secret",
+        "consumes": [
+          "application/json-patch+json",
+          "application/merge-patch+json",
+          "application/strategic-merge-patch+json",
+          "application/apply-patch+yaml"
+        ],
+        "produces": [
+          "application/json",
+          "application/yaml",
+          "application/vnd.kubernetes.protobuf"
+        ],
+        "schemes": [
+          "https"
+        ],
+        "tags": [
+          "core_v1"
+        ],
+        "operationId": "patchCoreV1NamespacedSecret",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+            }
+          },
+          {
+            "uniqueItems": true,
+            "type": "string",
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "name": "dryRun",
+            "in": "query"
+          },
+          {
+            "uniqueItems": true,
+            "type": "string",
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+            "name": "fieldManager",
+            "in": "query"
+          },
+          {
+            "uniqueItems": true,
+            "type": "boolean",
+            "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+            "name": "force",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/io.k8s.api.core.v1.Secret"
+            }
+          },
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/io.k8s.api.core.v1.Secret"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "x-kubernetes-action": "patch",
+        "x-kubernetes-group-version-kind": {
+          "group": "",
+          "kind": "Secret",
+          "version": "v1"
+        }
+      },
+      "parameters": [
+        {
+          "uniqueItems": true,
+          "type": "string",
+          "description": "name of the Secret",
+          "name": "name",
+          "in": "path",
+          "required": true
+        },
+        {
+          "uniqueItems": true,
+          "type": "string",
+          "description": "object name and auth scope, such as for teams and projects",
+          "name": "namespace",
+          "in": "path",
+          "required": true
+        },
+        {
+          "uniqueItems": true,
+          "type": "string",
+          "description": "If 'true', then the output is pretty printed.",
+          "name": "pretty",
+          "in": "query"
+        }
+      ]
+		      
+    }
+  },
+  "definitions": {
+    "io.k8s.api.core.v1.Secret": {
+      "description": "Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.",
+      "type": "object",
+      "properties": {
+	"apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+	},
+	"data": {
+          "description": "Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "format": "byte"
+          }
+	},
+	"immutable": {
+          "description": "Immutable, if set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil.",
+          "type": "boolean"
+	},
+	"kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+	},
+	"metadata": {
+          "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+	},
+	"stringData": {
+          "description": "stringData allows specifying non-binary secret data in string form. It is provided as a write-only input field for convenience. All keys and values are merged into the data field on write, overwriting any existing values. The stringData field is never output when reading from the API.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+	},
+	"type": {
+          "description": "Used to facilitate programmatic handling of secret data. More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types",
+          "type": "string"
+	}
+      },
+      "x-kubernetes-group-version-kind": [
+	{
+          "group": "",
+          "kind": "Secret",
+          "version": "v1"
+	}
+      ]
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions": {
+      "description": "DeleteOptions may be provided when deleting an API object.",
+      "type": "object",
+      "properties": {
+	"apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+	},
+	"dryRun": {
+          "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+	},
+	"gracePeriodSeconds": {
+          "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+          "type": "integer",
+          "format": "int64"
+	},
+	"kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+	},
+	"orphanDependents": {
+          "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+          "type": "boolean"
+	},
+	"preconditions": {
+          "description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions"
+	},
+	"propagationPolicy": {
+          "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+          "type": "string"
+	}
+      },
+      "x-kubernetes-group-version-kind": [
+	{
+          "group": "",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "admission.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "admission.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "admissionregistration.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "admissionregistration.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "apiextensions.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "apiextensions.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "apiregistration.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "apiregistration.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "apps",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "apps",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "apps",
+          "kind": "DeleteOptions",
+          "version": "v1beta2"
+	},
+	{
+          "group": "authentication.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "authentication.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "authorization.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "authorization.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "autoscaling",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "autoscaling",
+          "kind": "DeleteOptions",
+          "version": "v2"
+	},
+	{
+          "group": "autoscaling",
+          "kind": "DeleteOptions",
+          "version": "v2beta1"
+	},
+	{
+          "group": "autoscaling",
+          "kind": "DeleteOptions",
+          "version": "v2beta2"
+	},
+	{
+          "group": "batch",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "batch",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "certificates.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "certificates.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "coordination.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "coordination.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "discovery.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "discovery.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "events.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "events.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "extensions",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "flowcontrol.apiserver.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+	},
+	{
+          "group": "flowcontrol.apiserver.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "flowcontrol.apiserver.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta2"
+	},
+	{
+          "group": "imagepolicy.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+	},
+	{
+          "group": "internal.apiserver.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+	},
+	{
+          "group": "networking.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "networking.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "node.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "node.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+	},
+	{
+          "group": "node.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "policy",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "policy",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "rbac.authorization.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "rbac.authorization.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+	},
+	{
+          "group": "rbac.authorization.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "scheduling.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "scheduling.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+	},
+	{
+          "group": "scheduling.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	},
+	{
+          "group": "storage.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1"
+	},
+	{
+          "group": "storage.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1alpha1"
+	},
+	{
+          "group": "storage.k8s.io",
+          "kind": "DeleteOptions",
+          "version": "v1beta1"
+	}
+      ]
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+      "description": "Status is a return value for calls that don't return other objects.",
+      "type": "object",
+      "properties": {
+	"apiVersion": {
+          "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+          "type": "string"
+	},
+	"code": {
+          "description": "Suggested HTTP return code for this status, 0 if not set.",
+          "type": "integer",
+          "format": "int32"
+	},
+	"details": {
+          "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails"
+	},
+	"kind": {
+          "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "type": "string"
+	},
+	"message": {
+          "description": "A human-readable description of the status of this operation.",
+          "type": "string"
+	},
+	"metadata": {
+          "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+	},
+	"reason": {
+          "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+          "type": "string"
+	},
+	"status": {
+          "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+          "type": "string"
+	}
+      },
+      "x-kubernetes-group-version-kind": [
+	{
+          "group": "",
+          "kind": "Status",
+          "version": "v1"
+	}
+      ]
+    },
+    "io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
+      "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+      "type": "object"
+    }
+
+  },
+  "securityDefinitions": {
+    "BearerToken": {
+      "description": "Bearer Token authentication",
+      "type": "apiKey",
+      "name": "authorization",
+      "in": "header"
+    }
+  },
+  "security": [
+    {
+      "BearerToken": []
+    }
+  ]
+}

--- a/core/test/martian/swagger_test.cljc
+++ b/core/test/martian/swagger_test.cljc
@@ -66,6 +66,13 @@
                    (s/optional-key :systems) [s/Int]}}
            (:body-schema handler)))))
 
+(deftest body-object-without-any-parameters-takes-values
+  (is (= {:body {s/Any s/Any}}
+         (let [[handler] (->> (json-resource "kubernetes-swagger-v2.json")
+                              (swagger/swagger->handlers)
+                              (filter #(= (:route-name %) :patch-core-v-1-namespaced-secret)))]
+           (:body-schema handler)))))
+
 (deftest response-schema-test
   (let [swagger-json
         {:paths {(keyword "/pets/{id}")


### PR DESCRIPTION
This pull request fixes an issue encountered using the Kubernetes "Patch" API where Martian complains that the patch body parameter can't have any properties. This is because a patch reference in the body field is defined as follows:

"io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
      "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
      "type": "object"
  }

This "object" does not define any parameters or additionalParameters and _I think_ (based on my limited reading of the Swagger v2 and JSON schema specs that this means that the 'object' can have any parameters.

I've included a test case to detect this scenario and the code change does not impact any other Martian tests but I'm not yet 100% certain about this and am interested in whether this pull request might be acceptable.

This code solves my specific problem calling :patch-core-v-1-namespaced-secret but is not extensively tested.