### PR TITLE
add support for the deprecated field on the operation

### DIFF
--- a/core/src/martian/core.cljc
+++ b/core/src/martian/core.cljc
@@ -107,16 +107,16 @@
 (defn explore
   ([martian] (mapv (juxt :route-name :summary) (:handlers (resolve-instance martian))))
   ([martian route-name]
-   (when-let [{:keys [parameter-aliases summary deprecated] :as handler} (find-handler (:handlers (resolve-instance martian)) route-name)]
-     {:summary summary
-      :deprecated deprecated
-      :parameters (reduce (fn [params parameter-key]
-                            (merge params (alias-schema (get parameter-aliases parameter-key) (get handler parameter-key))))
-                          {}
-                          parameter-schemas)
-      :returns (->> (:response-schemas handler)
-                    (map (juxt (comp :v :status) :body))
-                    (into {}))})))
+   (when-let [{:keys [parameter-aliases summary deprecated?] :as handler} (find-handler (:handlers (resolve-instance martian)) route-name)]
+     (-> {:summary summary
+          :parameters (reduce (fn [params parameter-key]
+                                (merge params (alias-schema (get parameter-aliases parameter-key) (get handler parameter-key))))
+                              {}
+                              parameter-schemas)
+          :returns (->> (:response-schemas handler)
+                        (map (juxt (comp :v :status) :body))
+                        (into {}))}
+         (cond-> deprecated? (assoc :deprecated? true))))))
 
 (defn- build-instance [api-root handlers {:keys [interceptors] :as opts}]
   (->Martian api-root handlers (or interceptors default-interceptors) (dissoc opts :interceptors)))

--- a/core/src/martian/core.cljc
+++ b/core/src/martian/core.cljc
@@ -107,8 +107,9 @@
 (defn explore
   ([martian] (mapv (juxt :route-name :summary) (:handlers (resolve-instance martian))))
   ([martian route-name]
-   (when-let [{:keys [parameter-aliases summary] :as handler} (find-handler (:handlers (resolve-instance martian)) route-name)]
+   (when-let [{:keys [parameter-aliases summary deprecated] :as handler} (find-handler (:handlers (resolve-instance martian)) route-name)]
      {:summary summary
+      :deprecated deprecated
       :parameters (reduce (fn [params parameter-key]
                             (merge params (alias-schema (get parameter-aliases parameter-key) (get handler parameter-key))))
                           {}

--- a/core/src/martian/openapi.cljc
+++ b/core/src/martian/openapi.cljc
@@ -188,6 +188,7 @@
        :produces           (vec (keep :content-type responses))
        :consumes           [(:content-type body)]
        :summary            (:summary definition)
+       :deprecated         (boolean (:deprecated definition))
        :description        (:description definition)
        :openapi-definition definition
        :route-name         (->kebab-case-keyword (:operationId definition))})))

--- a/core/src/martian/openapi.cljc
+++ b/core/src/martian/openapi.cljc
@@ -177,18 +177,18 @@
                 responses  (process-responses (update-vals-future (:responses definition)
                                                                   (partial resolve-ref components))
                                               components (:decodes content-types))]]
-      {:path-parts         (vec (tokenise-path url))
-       :method             method
-       :path-schema        (process-parameters (:path parameters) components)
-       :query-schema       (process-parameters (:query parameters) components)
-       :body-schema        (:schema body)
-       :form-schema        (process-parameters (:form parameters) components)
-       :headers-schema     (process-parameters (:header parameters) components)
-       :response-schemas   (vec (keep #(dissoc % :content-type) responses))
-       :produces           (vec (keep :content-type responses))
-       :consumes           [(:content-type body)]
-       :summary            (:summary definition)
-       :deprecated         (boolean (:deprecated definition))
-       :description        (:description definition)
-       :openapi-definition definition
-       :route-name         (->kebab-case-keyword (:operationId definition))})))
+      (-> {:path-parts         (vec (tokenise-path url))
+           :method             method
+           :path-schema        (process-parameters (:path parameters) components)
+           :query-schema       (process-parameters (:query parameters) components)
+           :body-schema        (:schema body)
+           :form-schema        (process-parameters (:form parameters) components)
+           :headers-schema     (process-parameters (:header parameters) components)
+           :response-schemas   (vec (keep #(dissoc % :content-type) responses))
+           :produces           (vec (keep :content-type responses))
+           :consumes           [(:content-type body)]
+           :summary            (:summary definition)
+           :description        (:description definition)
+           :openapi-definition definition
+           :route-name         (->kebab-case-keyword (:operationId definition))}
+          (cond-> (:deprecated definition) (assoc :deprecated? true))))))


### PR DESCRIPTION
When an operation is deprecated in the openapi spec this PR makes the `deprecated` field available when exploring the endpoint.
