### PR TITLE
Fix requirement of nested objects

### DIFF
--- a/core/bb.edn
+++ b/core/bb.edn
@@ -2,7 +2,8 @@
  :tasks
  {test:bb {:extra-paths ["test" "test-resources" "../test-common"]
            :extra-deps {io.github.cognitect-labs/test-runner
-                        {:git/tag "v0.5.0" :git/sha "b3fd0d2"}}
+                        {:git/tag "v0.5.0" :git/sha "b3fd0d2"}
+                        nubank/matcher-combinators {:mvn/version "3.8.5"}}
            :requires ([martian.core-test]
                       [martian.interceptors-test]
                       [martian.openapi-test])

--- a/core/project.clj
+++ b/core/project.clj
@@ -27,7 +27,8 @@
                                   [com.bhauman/figwheel-main "0.2.13"]
                                   [org.clojure/tools.reader "1.3.5"]
                                   [cider/piggieback "0.5.2"]
-                                  [org.clojure/tools.nrepl "0.2.13"]]
+                                  [org.clojure/tools.nrepl "0.2.13"]
+                                  [nubank/matcher-combinators "3.8.5"]]
                    :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]}}}
   :aliases {"fig"       ["trampoline" "run" "-m" "figwheel.main"]
             "fig:build" ["trampoline" "run" "-m" "figwheel.main" "-b" "dev" "-r"]

--- a/core/src/martian/schema.cljc
+++ b/core/src/martian/schema.cljc
@@ -65,8 +65,6 @@
   [ref-lookup parameters]
   (->> parameters
        (map (fn [{:keys [name required] :as param}]
-              (when (= name :selector)
-                (def a param))
               {(cond-> (keyword name)
                  (not required)
                  s/optional-key)
@@ -119,7 +117,7 @@
                                                            (denormalise-object-properties param))))
                     param)
                   :name parameter-name
-                  :denormalised true
+                  ;:denormalised true
                   :required (or (when-not (= "object" (:type param))
                                   (:required param))
                                 (and (coll? required)
@@ -173,47 +171,3 @@
         (and (not required)
              (not= "array" type) (not= "array" (:type schema)))
         s/maybe))))
-
-(comment
-  (require '[matcher-combinators.standalone])
-
-  (def parameter-object {:name "body",
-                         :in "body",
-                         :required ["spec"],
-                         :description "NetworkChaos is the Schema for the networkchaos API",
-                         :type "object",
-                         :properties {:apiVersion {:description "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-                                                   :type "string"},
-                                      :kind {:description "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-                                             :type "string"},
-                                      :metadata {:description "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-                                                 :$ref "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"},
-                                      :spec {:description "Spec defines the behavior of a pod chaos experiment",
-                                             :type "object",
-                                             :required ["action" "mode" "selector" "duration"],
-                                             :properties {:selector {:description "Selector is used to select pods that are used to inject chaos action.",
-                                                                     :type "object",
-                                                                     :required ["abc" "namespaces"],
-                                                                     :properties {:namespaces {:description "Namespaces is a set of namespace to which objects belong.",
-                                                                                               :type "array",
-                                                                                               :items {:type "string"}},
-                                                                                  :abc2 {:description "Map of string keys and values that can be used to select objects. A selector based on fields.",
-                                                                                         :type "object",
-                                                                                         :additionalProperties {:type "string"}},
-                                                                                  :abc {:description "Map of string keys and values that can be used to select objects. A selector based on fields.",
-                                                                                        :type "object",
-                                                                                        :additionalProperties {:type "string"}}}},
-                                                          :mode {:description "Mode defines the mode to run chaos action. Supported mode: one / all / fixed / fixed-percent / random-max-percent",
-                                                                 :type "string",
-                                                                 :enum ["one" "all" "fixed" "fixed-percent" "random-max-percent"]},
-                                                          :duration {:description "Duration represents the duration of the chaos action",
-                                                                     :type "string"},
-                                                          :action {:description "Action defines the specific network chaos action. Supported action: partition, netem, delay, loss, duplicate, corrupt Default action: delay",
-                                                                   :type "string",
-                                                                   :enum ["netem" "delay" "loss" "duplicate" "corrupt" "partition" "bandwidth"]}}}},
-                         :x-kubernetes-group-version-kind [{:group "chaos-mesh.org", :kind "NetworkChaos", :version "v1alpha1"}]})
-
-  ; this two shouldn't differ!
-  (matcher-combinators.standalone/match
-    (denormalise-object-properties (-> parameter-object :properties :spec))
-    (denormalise-object-properties (first (filter #(= :spec (:name %)) (denormalise-object-properties parameter-object))))))

--- a/core/src/martian/schema.cljc
+++ b/core/src/martian/schema.cljc
@@ -117,7 +117,7 @@
                                                            (denormalise-object-properties param))))
                     param)
                   :name parameter-name
-                  ;:denormalised true
+                  :denormalised true
                   :required (or (when-not (= "object" (:type param))
                                   (:required param))
                                 (and (coll? required)

--- a/core/src/martian/schema.cljc
+++ b/core/src/martian/schema.cljc
@@ -6,7 +6,7 @@
             [schema-tools.core :as st]
             [schema-tools.coerce :as stc]
             [martian.parameter-aliases :refer [unalias-data]])
-  #?(:clj (:import [schema.core AnythingSchema Maybe EnumSchema EqSchema])))
+  #?(:clj (:import [schema.core AnythingSchema Maybe EnumSchema EqSchema OptionalKey])))
 
 (defn- keyword->string [s]
   (if (keyword? s) (name s) s))
@@ -65,6 +65,8 @@
   [ref-lookup parameters]
   (->> parameters
        (map (fn [{:keys [name required] :as param}]
+              (when (= name :selector)
+                (def a param))
               {(cond-> (keyword name)
                  (not required)
                  s/optional-key)
@@ -110,15 +112,18 @@
 
 (defn- denormalise-object-properties [{:keys [required properties] :as s}]
   (map (fn [[parameter-name param]]
-         (assoc (if (= "object" (:type param))
-                  (assoc param :properties (into {} (map (juxt :name identity)
-                                                         (denormalise-object-properties param))))
-                  param)
-                :name parameter-name
-                :required (or (when-not (= "object" (:type param))
-                                (:required param))
-                              (and (coll? required)
-                                   (contains? (set required) (name parameter-name))))))
+         (if (:denormalised param)
+           param
+           (assoc (if (= "object" (:type param))
+                    (assoc param :properties (into {} (map (juxt :name identity)
+                                                           (denormalise-object-properties param))))
+                    param)
+                  :name parameter-name
+                  :denormalised true
+                  :required (or (when-not (= "object" (:type param))
+                                  (:required param))
+                                (and (coll? required)
+                                     (contains? (set required) (name parameter-name)))))))
        properties))
 
 (defn- make-object-schema [ref-lookup {:keys [additionalProperties] :as schema}]
@@ -168,3 +173,47 @@
         (and (not required)
              (not= "array" type) (not= "array" (:type schema)))
         s/maybe))))
+
+(comment
+  (require '[matcher-combinators.standalone])
+
+  (def parameter-object {:name "body",
+                         :in "body",
+                         :required ["spec"],
+                         :description "NetworkChaos is the Schema for the networkchaos API",
+                         :type "object",
+                         :properties {:apiVersion {:description "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                                                   :type "string"},
+                                      :kind {:description "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                             :type "string"},
+                                      :metadata {:description "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                                                 :$ref "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"},
+                                      :spec {:description "Spec defines the behavior of a pod chaos experiment",
+                                             :type "object",
+                                             :required ["action" "mode" "selector" "duration"],
+                                             :properties {:selector {:description "Selector is used to select pods that are used to inject chaos action.",
+                                                                     :type "object",
+                                                                     :required ["abc" "namespaces"],
+                                                                     :properties {:namespaces {:description "Namespaces is a set of namespace to which objects belong.",
+                                                                                               :type "array",
+                                                                                               :items {:type "string"}},
+                                                                                  :abc2 {:description "Map of string keys and values that can be used to select objects. A selector based on fields.",
+                                                                                         :type "object",
+                                                                                         :additionalProperties {:type "string"}},
+                                                                                  :abc {:description "Map of string keys and values that can be used to select objects. A selector based on fields.",
+                                                                                        :type "object",
+                                                                                        :additionalProperties {:type "string"}}}},
+                                                          :mode {:description "Mode defines the mode to run chaos action. Supported mode: one / all / fixed / fixed-percent / random-max-percent",
+                                                                 :type "string",
+                                                                 :enum ["one" "all" "fixed" "fixed-percent" "random-max-percent"]},
+                                                          :duration {:description "Duration represents the duration of the chaos action",
+                                                                     :type "string"},
+                                                          :action {:description "Action defines the specific network chaos action. Supported action: partition, netem, delay, loss, duplicate, corrupt Default action: delay",
+                                                                   :type "string",
+                                                                   :enum ["netem" "delay" "loss" "duplicate" "corrupt" "partition" "bandwidth"]}}}},
+                         :x-kubernetes-group-version-kind [{:group "chaos-mesh.org", :kind "NetworkChaos", :version "v1alpha1"}]})
+
+  ; this two shouldn't differ!
+  (matcher-combinators.standalone/match
+    (denormalise-object-properties (-> parameter-object :properties :spec))
+    (denormalise-object-properties (first (filter #(= :spec (:name %)) (denormalise-object-properties parameter-object))))))

--- a/core/test/martian/schema_test.cljc
+++ b/core/test/martian/schema_test.cljc
@@ -397,52 +397,36 @@
            schema))))
 
 
-(def definition {:org.chaos-mesh.v1alpha1.NetworkChaos {:description "NetworkChaos is the Schema for the networkchaos API",
-                                                        :type "object",
-                                                        :required ["spec"],
-                                                        :properties {:apiVersion {:description "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-                                                                                  :type "string"},
-                                                                     :kind {:description "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-                                                                            :type "string"},
-                                                                     :metadata {:description "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-                                                                                :$ref "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"},
-                                                                     :spec {:description "Spec defines the behavior of a pod chaos experiment",
-                                                                            :type "object",
-                                                                            :required ["action" "mode" "selector"],
-                                                                            :properties {:selector {:description "Selector is used to select pods that are used to inject chaos action.",
-                                                                                                    :type "object",
-                                                                                                    :required ["namespaces" "fieldSelectors"]
-                                                                                                    :properties {:namespaces {:description "Namespaces is a set of namespace to which objects belong."
-                                                                                                                              :type "array"
-                                                                                                                              :items {:type "string"}}
-                                                                                                                 :fieldSelectors {:description "Map of string keys and values that can be used to select objects. A selector based on fields."
-                                                                                                                                  :type "object"
-                                                                                                                                  :additionalProperties {:type "string"}}
-                                                                                                                 :pods {:description "Pods is a map of string keys and a set values that used to select pods. The key defines the namespace which pods belong, and the each values is a set of pod names."
-                                                                                                                        :type "object"
-                                                                                                                        :additionalProperties {:type "array"
-                                                                                                                                               :items {:type "string"}}}}}
-                                                                                         :mode {:description "Mode defines the mode to run chaos action. Supported mode: one / all / fixed / fixed-percent / random-max-percent",
-                                                                                                :type "string",
-                                                                                                :enum ["one"
-                                                                                                       "all"
-                                                                                                       "fixed"
-                                                                                                       "fixed-percent"
-                                                                                                       "random-max-percent"]},
-                                                                                         :duration {:description "Duration represents the duration of the chaos action",
-                                                                                                    :type "string"},
-                                                                                         :action {:description "Action defines the specific network chaos action. Supported action: partition, netem, delay, loss, duplicate, corrupt Default action: delay",
-                                                                                                  :type "string",
-                                                                                                  :enum ["netem"
-                                                                                                         "delay"
-                                                                                                         "loss"
-                                                                                                         "duplicate"
-                                                                                                         "corrupt"
-                                                                                                         "partition"
-                                                                                                         "bandwidth"]}}}}
-                                                        :x-kubernetes-group-version-kind [{:group "chaos-mesh.org"
-                                                                                           :kind "NetworkChaos"
-                                                                                           :version "v1alpha1"}]}})
+(def definition {:org.chaos-mesh.v1alpha1.NetworkChaos
+                 {:description "NetworkChaos is the Schema for the networkchaos API"
+                  :type "object"
+                  :required ["spec"]
+                  :properties {:spec {:type "object"
+                                      :required ["action" "mode" "selector"]
+                                      :properties {:selector {:type "object"
+                                                              :required ["namespaces" "fieldSelectors"]
+                                                              :properties {:namespaces {:type "array"
+                                                                                        :items {:type "string"}}
+                                                                           :fieldSelectors {:type "object"
+                                                                                            :additionalProperties {:type "string"}}
+                                                                           :pods {:type "object"
+                                                                                  :additionalProperties {:type "array"
+                                                                                                         :items {:type "string"}}}}}
+                                                   :mode {:type "string"
+                                                          :enum ["one"
+                                                                 "all"
+                                                                 "fixed"
+                                                                 "fixed-percent"
+                                                                 "random-max-percent"]}
+                                                   :duration {:type "string"}
+                                                   :action {:type "string"
+                                                            :enum ["netem"
+                                                                   "delay"
+                                                                   "loss"
+                                                                   "duplicate"
+                                                                   "corrupt"
+                                                                   "partition"
+                                                                   "bandwidth"]}}}}}})
 
 (deftest require-nested-objects
   (let [schema (schema/make-schema {:definitions definition}


### PR DESCRIPTION
### The problem

Nested objects mark as required in a swagger Schema Object are translated to optional keys.
See the test `require-nested-objects` for an real use case obtained from the k8s api with chaos-mesh installed.

### A possible solution

The solution implemented in this PR is adding a `denormalised` attribute to prevent being denormalised again which seems to be what is causing the issue. 
Perhaps someone with a better understanding of the codebase can provide a more principled solution.
The main contribution is the test showing which scenario is not working properly.