### PR TITLE
Fixed spec validation failure when no content-type present for request

### DIFF
--- a/core/src/martian/openapi.cljc
+++ b/core/src/martian/openapi.cljc
@@ -186,7 +186,8 @@
            :headers-schema     (process-parameters (:header parameters) components)
            :response-schemas   (vec (keep #(dissoc % :content-type) responses))
            :produces           (vec (keep :content-type responses))
-           :consumes           [(:content-type body)]
+           :consumes           (when-let [content-type (:content-type body)]
+                                 [content-type])
            :summary            (:summary definition)
            :description        (:description definition)
            :openapi-definition definition

--- a/core/test/martian/openapi_test.cljc
+++ b/core/test/martian/openapi_test.cljc
@@ -84,7 +84,7 @@
             :form-schema nil,
             :path-parts ["/project/" :projectKey],
             :headers-schema {(s/optional-key :userAuthToken) s/Str},
-            :consumes [nil],
+            :consumes nil
             :summary "Get specific values from a configuration for a specific project",
             :body-schema nil,
             :route-name :get-project-configuration,


### PR DESCRIPTION
Ref: Originating [issue](https://github.com/wkok/openai-clojure/issues/25)

When [spec instrumentation](https://clojure.org/guides/spec#_instrumentation_and_testing) is enabled, and bootstrapping a martian using an OpenAPI v3 definition containing no content-type declaration for the request (for example a GET), then spec validation fails for example:

Definition with no content-type declaration for the request:
```yaml
openapi: 3.0.0
info:
  title: OpenAI API
  description: APIs for sampling from and fine-tuning language models
  version: '1.3.0'
servers:
  - url: https://api.openai.com/v1
paths:
  /models:
    get:
      operationId: listModels
      summary: Lists the currently available models
      responses:
        "200":
          description: OK
          content:
            application/json:
              schema: {}

``` 

In a test namespace, enable spec instrumentation:
```clojure
(ns wkok.openai-clojure.api-test
  (:require [clojure.spec.test.alpha :as stest]))

(stest/instrument `martian.core/build-instance)

(martian/bootstrap-openapi ... )   ;; bootstrap using above yaml
```

results in validation error:
```
1. Caused by clojure.lang.ExceptionInfo
   Spec assertion failed.

         Spec: #object[clojure.spec.alpha$regex_spec_impl$reify__2510 0x663073a3 "clojure.spec.alpha$regex_spec_impl$reify__2510@663073a3"]
        Value: ("https://api.openai.com/v1"
                ({:description nil,
                  :method :get,

...

     Problems: 

            val: [nil]
             in: [1 0 :consumes]
         failed: nil?
           spec: :martian.spec/content-types
             at: [:handlers :consumes :clojure.spec.alpha/nil]

            val: nil
             in: [1 0 :consumes 0]
         failed: string?
           spec: :martian.spec/content-types
             at: [:handlers :consumes :clojure.spec.alpha/pred]

```

This PR fixes it by ensuring `nil` for `:consumes` in this case instead of `[nil]`