### PR TITLE
patch for inf as a default value

### DIFF
--- a/core/src/martian/schema.cljc
+++ b/core/src/martian/schema.cljc
@@ -98,7 +98,13 @@
 
 (defn wrap-default [{:keys [default]} schema]
   (if (some? default)
-    (st/default schema default)
+    (let [default
+          ;patch for `inf` as a default value
+          (if (and (= schema s/Int) (= default "inf"))
+            #?(:clj Long/MAX_VALUE
+               :cljs (Math/pow 10 1000))
+            default)]
+      (st/default schema default))
     schema))
 
 (defn- schema-type [ref-lookup {:keys [type $ref] :as param}]

--- a/core/test/martian/schema_test.cljc
+++ b/core/test/martian/schema_test.cljc
@@ -68,7 +68,8 @@
 (deftest default-values-test
   (testing "explaining and printing"
     (is (= '(default Int 123)
-           (s/explain (st/default s/Int 123)))))
+           (s/explain (schema/wrap-default 123 s/Int))))
+    (is (= nil (s/explain (schema/wrap-default "inf" s/Int)))))
 
   (let [schema (schema/schemas-for-parameters {} [{:name "id"
                                                    :in "path"


### PR DESCRIPTION
https://github.com/openai/openai-openapi/blob/5c1857ea865e74e45e3b12064e0cc2396ef64be1/openapi.yaml#L6012C2-L6012C2

The default value for the integer is "inf"