### PR TITLE
Fix Reference Object usage on parameters for swagger spec

### DIFF
--- a/core/src/martian/schema.cljc
+++ b/core/src/martian/schema.cljc
@@ -75,6 +75,11 @@
   (let [[_ category k] (re-find #"#/(definitions|parameters)/(.*)" ref)]
     (get-in ref-lookup [(keyword category) (keyword k)])))
 
+(defn resolve-ref-param [ref-lookup param]
+  (if-let [ref (:$ref param)]
+    (resolve-ref ref-lookup ref)
+    param))
+
 (def URI
   #?(:clj java.net.URI
      :cljs goog.Uri))

--- a/core/src/martian/swagger.cljc
+++ b/core/src/martian/swagger.cljc
@@ -7,24 +7,30 @@
             [schema.core :as s]
             [martian.utils :as utils]))
 
+(defn resolve-swagger-params [ref-lookup swagger-params category]
+  (->> swagger-params
+       (map (partial schema/resolve-ref-param ref-lookup))
+       (filter #(= category (:in %)))
+       not-empty))
+
 (defn- body-schema [ref-lookup swagger-params]
-  (when-let [body-params (not-empty (filter #(= "body" (:in %)) swagger-params))]
+  (when-let [body-params (resolve-swagger-params ref-lookup swagger-params "body")]
     (schema/schemas-for-parameters ref-lookup body-params)))
 
 (defn- form-schema [ref-lookup swagger-params]
-  (when-let [form-params (not-empty (filter #(= "formData" (:in %)) swagger-params))]
+  (when-let [form-params (resolve-swagger-params ref-lookup swagger-params "formData")]
     (schema/schemas-for-parameters ref-lookup form-params)))
 
 (defn- path-schema [ref-lookup swagger-params]
-  (when-let [path-params (not-empty (filter #(= "path" (:in %)) swagger-params))]
+  (when-let [path-params (resolve-swagger-params ref-lookup swagger-params "path")]
     (schema/schemas-for-parameters ref-lookup path-params)))
 
 (defn- query-schema [ref-lookup swagger-params]
-  (when-let [query-params (not-empty (filter #(= "query" (:in %)) swagger-params))]
+  (when-let [query-params (resolve-swagger-params ref-lookup swagger-params "query")]
     (schema/schemas-for-parameters ref-lookup query-params)))
 
 (defn- headers-schema [ref-lookup swagger-params]
-  (when-let [header-params (not-empty (filter #(= "header" (:in %)) swagger-params))]
+  (when-let [header-params (resolve-swagger-params ref-lookup swagger-params "header")]
     (schema/schemas-for-parameters ref-lookup header-params)))
 
 (defn- response-schemas [ref-lookup swagger-responses]

--- a/core/src/martian/swagger.cljc
+++ b/core/src/martian/swagger.cljc
@@ -9,7 +9,7 @@
 
 (defn resolve-swagger-params [ref-lookup swagger-params category]
   (->> swagger-params
-       (map (partial schema/resolve-ref-param ref-lookup))
+       (map (schema/resolve-ref-fn ref-lookup))
        (filter #(= category (:in %)))
        not-empty))
 

--- a/core/test/martian/swagger_test.cljc
+++ b/core/test/martian/swagger_test.cljc
@@ -18,6 +18,28 @@
     (is (= {:id s/Str} (:path-schema get-handler)))
     (is (= nil (:query-schema get-handler)))))
 
+(deftest parameter-schemas-ref-test
+  (let [params {:idParam {:name     "id"
+                         :in       "path"
+                         :type     "string"
+                         :required "true"}}]
+    (is (= {:id s/Str} (-> {:definitions params
+                            "paths"      {"/pets/{id}"
+                                          {"get" {"operationId" "getPetById"
+                                                  "method"      "get"
+                                                  "parameters"  [{"$ref" "#/definitions/idParam"}]}}}}
+                           swagger/swagger->handlers
+                           first
+                           :path-schema)))
+    (is (= {:id s/Str} (-> {:definitions params
+                            "paths"      {"/pets/{id}"
+                                          {"parameters" [{"$ref" "#/definitions/idParam"}]
+                                           "get"        {"operationId" "getPetById"
+                                                         "method"      "get"}}}}
+                           swagger/swagger->handlers
+                           first
+                           :path-schema)))))
+
 (deftest path-item-obj-parameters-test
   (let [[get-handler delete-handler]
         (swagger/swagger->handlers {"paths" {"/pets/{id}"


### PR DESCRIPTION
As I commented in the issue
https://github.com/oliyh/martian/issues/195

This is not working for swagger, but it is for OpenAPI v3. I tried to refactor the code to use the same logic, adding tests for it.
