### PR TITLE
Terminate the stack but don't remove the rest when using VCR

### DIFF
--- a/vcr/src/martian/vcr.cljc
+++ b/vcr/src/martian/vcr.cljc
@@ -100,10 +100,10 @@
      :enter (fn [ctx]
               (let [request-count (inc-counter! counters ctx)]
                 (if-let [response (load-response opts (assoc ctx ::request-count request-count))]
-                  (assoc (tc/terminate ctx) :response response)
+                  (-> ctx (assoc :response response) tc/terminate)
                   (condp = on-missing-response
                     :throw-error (let [message (str "No response stored for request " (request-op ctx) " " (request-key ctx))]
                                    (throw #?(:clj (Exception. message)
                                              :cljs (js/Error. message))))
-                    :generate-404 (assoc (tc/terminate ctx) :response {:status 404})
+                    :generate-404 (-> ctx (assoc :response {:status 404}) tc/terminate)
                     ctx))))}))

--- a/vcr/test/martian/vcr_test.cljc
+++ b/vcr/test/martian/vcr_test.cljc
@@ -1,27 +1,48 @@
 (ns martian.vcr-test
   (:require #?(:clj [clojure.test :refer [deftest testing is]]
                :cljs [cljs.test :refer [deftest testing is]])
+            [clojure.edn :as edn]
             [martian.vcr :as vcr]
             [martian.core :as m]
+            [martian.interceptors :as mi]
             [schema.core :as s]
             #?(:clj [clojure.java.io :as io])))
 
+
 #?(:cljs (def Exception js/Error))
+
+(def interceptors
+  "Like default-interceptors but adds response coercion to ensure the interceptor chain actually runs completely (including the :leave stage)."
+  (conj m/default-interceptors mi/default-coerce-response))
 
 (def dummy-response
   {:status 200
    :headers {"Content-Type" "application/json"}
-   :body {:foo "bar"}})
+   :body "{\"foo\": \"bar\"}"})
+
+(def cooked-response
+  (assoc dummy-response :body {:foo "bar"}))
 
 (def dummy-responder
   {:name ::dummy
-   :leave (fn [ctx]
-            (assoc ctx :response dummy-response))})
+   :leave (fn [ctx] (assoc ctx :response dummy-response))})
 
-(def routes [{:route-name :load-pet
-              :path-parts ["/pets/" :id]
-              :method :get
-              :path-schema {:id s/Int}}])
+(def routes
+  [{:route-name :load-pet
+    :path-parts ["/pets/" :id]
+    :method :get
+    :path-schema {:id s/Int}}])
+
+(def bootstrap
+  (partial m/bootstrap "http://foo.com" routes))
+
+(defn recording-boostrap
+  [vcr-opts]
+  (bootstrap {:interceptors (into interceptors [(vcr/record vcr-opts) dummy-responder])}))
+
+(defn playback-boostrap
+  [vcr-opts]
+  (bootstrap {:interceptors (into interceptors [(vcr/playback vcr-opts)])}))
 
 (deftest vcr-test
   #?(:clj
@@ -32,41 +53,35 @@
                    :extra-requests :repeat-last}]
 
          (testing "recording"
-           (let [m (m/bootstrap "http://foo.com" routes {:interceptors (into m/default-interceptors
-                                                                             [(vcr/record opts)
-                                                                              dummy-responder])})]
+           (let [m (recording-boostrap opts)]
              (is (= dummy-response (m/response-for m :load-pet {:id 123})))
-             (is (.exists (io/file "target" "load-pet" (str (hash {:id 123})) "0.edn"))))
+             (let [vcr-file (io/file "target" "load-pet" (str (hash {:id 123})) "0.edn")]
+               (is (.exists vcr-file))
+               (is (= dummy-response (edn/read-string (slurp vcr-file)))))))
 
-           (testing "and playback"
-             (let [m (m/bootstrap "http://foo.com" routes {:interceptors (into m/default-interceptors
-                                                                               [(vcr/playback opts)])})]
-               (is (= dummy-response (m/response-for m :load-pet {:id 123})))
+         (testing "and playback"
+           (let [m (playback-boostrap opts)]
+             (is (= cooked-response (m/response-for m :load-pet {:id 123})))
 
-               (testing "repeating last response"
-                 (is (= dummy-response (m/response-for m :load-pet {:id 123}))))))))))
+             (testing "repeating last response"
+               (is (= cooked-response (m/response-for m :load-pet {:id 123}))))))))))
 
-  (testing "atom store"
-    (let [store (atom {})
-          opts {:store {:kind :atom
-                        :store store}
-                :extra-requests :repeat-last}]
+(testing "atom store"
+  (let [store (atom {})
+        opts {:store {:kind :atom :store store}
+              :extra-requests :repeat-last}]
 
-      (testing "recording"
-        (let [m (m/bootstrap "http://foo.com" routes {:interceptors (into m/default-interceptors
-                                                                          [(vcr/record opts)
-                                                                           dummy-responder])})]
-          (is (= dummy-response (m/response-for m :load-pet {:id 123})))
-          (is (= dummy-response (get-in @store [:load-pet {:id 123} 0]))))
+    (testing "recording"
+      (let [m (recording-boostrap opts)]
+        (is (= cooked-response (m/response-for m :load-pet {:id 123})))
+        (is (= dummy-response (get-in @store [:load-pet {:id 123} 0]))))
 
-        (testing "and playback"
-          (let [m (m/bootstrap "http://foo.com" routes {:interceptors (into m/default-interceptors
-                                                                            [(vcr/playback opts)])})]
+      (testing "and playback"
+        (let [m (playback-boostrap opts)]
+          (is (= cooked-response (m/response-for m :load-pet {:id 123})))
 
-            (is (= dummy-response (m/response-for m :load-pet {:id 123})))
-
-            (testing "repeating last response"
-              (is (= dummy-response (m/response-for m :load-pet {:id 123}))))))))))
+          (testing "repeating last response"
+            (is (= cooked-response (m/response-for m :load-pet {:id 123})))))))))
 
 (deftest playback-interceptor-test
   (let [store (atom {:load-pet {{:id 123} {0 {:status 200 :body "Hello"}


### PR DESCRIPTION
References #181.

`remove-stack` prevents all further interceptors from running. It uses `terminate` under the hood. Critical difference: `terminate` just means we'd move to the second phase (`:leave`), ensuring things like e.g. response body encoding still happens.