### PR TITLE
Support setting coercion matchers via Martian `:opts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Martian
+
 Calling HTTP endpoints can be complicated. You have to construct the right URL with the right route parameters, remember
 what the query parameters are, what method to use, how to encode the body and many other things that leak into your codebase.
 
@@ -56,6 +57,7 @@ Testing and other interop libraries:
 
 
 ## Features
+
 - Bootstrap an instance from just a OpenAPI/Swagger url, a local definition file or provide your own API mapping
 - Modular with support for many HTTP client libraries (see table above)
 - Build urls and request maps from code or generate and perform the request, returning the response
@@ -84,7 +86,7 @@ like that provided by [pedestal-api](https://github.com/oliyh/pedestal-api):
 (require '[martian.core :as martian]
          '[martian.clj-http :as martian-http])
 
-;; bootstrap the martian instance by simply providing the url serving the openapi/swagger description
+;; bootstrap the Martian instance by simply providing the url serving the openapi/swagger description
 (let [m (martian-http/bootstrap-openapi "https://pedestal-api.herokuapp.com/swagger.json")]
 
   ;; explore the endpoints
@@ -162,6 +164,7 @@ Here's an example:
 ```
 
 ## Testing with martian-test
+
 Testing code that calls external systems can be tricky - you either build often elaborate stubs which start
 to become as complex as the system you are calling, or else you ignore it all together with `(constantly true)`.
 
@@ -195,6 +198,7 @@ previously untestable code testable again.
 More documentation is available at [martian-test](https://github.com/oliyh/martian/tree/master/test).
 
 ## Recording and playback with martian-vcr
+
 martian-vcr allows you to record responses from real HTTP requests and play them back later, allowing you to build realistic test
 data quickly and easily.
 
@@ -252,6 +256,7 @@ You may wish to provide additional behaviour to requests. This can be done by pr
 which behave in the same way as pedestal interceptors.
 
 ### Global behaviour
+
 You can add interceptors to the stack that get executed on every request when bootstrapping martian.
 For example, if you wish to add an authentication header and a timer to all requests:
 
@@ -284,6 +289,29 @@ For example, if you wish to add an authentication header and a timer to all requ
         (martian/response-for m :all-pets {:id 123}))
         ;; Request to :all-pets took 38ms
         ;; => {:status 200 :body {:pets []}}
+```
+
+There is also a way to augment/override the default coercion matcher that is used by a Martian instance for params coercion:
+
+```clojure
+;; adding an extra coercion instead/after the default one
+(martian-http/bootstrap-openapi
+  "https://pedestal-api.herokuapp.com/swagger.json"
+  {:coercion-matcher (fn [schema]
+                       (or (martian/default-coercion-matcher schema)
+                           (my-extra-coercion-matcher schema)))})
+
+;; switching to some coercion matcher from 'schema-tools'
+(require '[schema-tools.coerce :as stc])
+(martian/bootstrap
+  "https://api.org"
+  [{:route-name  :create-pet
+    :path-parts  ["/pets/"]
+    :method      :post
+    :body-schema {:pet {:PetId     s/Int
+                        :FirstName s/Str
+                        :LastName  s/Str}}}]
+  {:coercion-matcher stc/json-coercion-matcher})
 ```
 
 ### Per route behaviour

--- a/core/src/martian/core.cljc
+++ b/core/src/martian/core.cljc
@@ -1,18 +1,19 @@
 (ns martian.core
-  (:require [tripod.context :as tc]
-            [clojure.core.protocols]
+  (:require [clojure.core.protocols]
+            [clojure.spec.alpha :as spec]
             [clojure.string :as string]
             [clojure.walk :refer [keywordize-keys]]
+            [lambdaisland.uri :refer [map->query-string]]
             [martian.interceptors :as interceptors]
-            [martian.parameter-aliases :as parameter-aliases :refer [parameter-aliases alias-schema]]
-            [martian.swagger :refer [swagger->handlers]]
             [martian.openapi :refer [openapi->handlers openapi-schema?]]
-            [clojure.spec.alpha :as spec]
+            [martian.parameter-aliases :refer [parameter-aliases alias-schema]]
+            [martian.schema :as schema]
             [martian.spec :as mspec]
-            [lambdaisland.uri :refer [map->query-string]]))
+            [martian.swagger :refer [swagger->handlers]]
+            [tripod.context :as tc]))
 
 #?(:bb
-   ;; reflection issue in babasha -- TODO, submit patch upstream?
+   ;; reflection issue in babashka -- TODO, submit patch upstream?
    (do (defn- exception->ex-info [^Throwable exception execution-id interceptor stage]
          (ex-info (str "Interceptor Exception: " #?(:clj  (.getMessage exception)
                                                     :cljs (.-message exception)))
@@ -34,6 +35,8 @@
    interceptors/set-form-params
    interceptors/set-header-params
    interceptors/enqueue-route-specific-interceptors])
+
+(def default-coercion-matcher schema/default-coercion-matcher)
 
 (def ^:private parameter-schemas [:path-schema :query-schema :body-schema :form-schema :headers-schema])
 

--- a/core/src/martian/interceptors.cljc
+++ b/core/src/martian/interceptors.cljc
@@ -37,7 +37,7 @@
 
 (defn coerce-data [{:keys [parameter-aliases] :as handler} schema-key params opts]
   (let [coerce-opts (-> opts
-                        (select-keys [:coercion-matchers :use-defaults?])
+                        (select-keys [:coercion-matcher :use-defaults?])
                         (assoc :parameter-aliases (get parameter-aliases schema-key)))]
     (schema/coerce-data (get handler schema-key) params coerce-opts)))
 

--- a/core/src/martian/schema.cljc
+++ b/core/src/martian/schema.cljc
@@ -44,15 +44,15 @@
 
 (defn ->map-matcher
   "Builds a version of `stc/map-filter-matcher` that is optional and takes
-   into account custom `coercion-matchers` that may/not happen afterwards."
+   into account a custom `coercion-matchers` that may/not happen afterwards."
   [coercion-matchers]
   (fn [schema]
-    (let [f (stc/map-filter-matcher schema)]
+    (let [f (stc/map-filter-matcher schema)
+          g (coercion-matchers schema)]
       (fn [x]
-        (let [x' (if (some? f) (f x) x)]
-          (if-some [g (coercion-matchers schema)]
-            (g x')
-            x'))))))
+        (cond-> x
+                (some? f) (f)
+                (some? g) (g))))))
 
 (defn- from-maybe [s]
   (if (instance? Maybe s)

--- a/core/test/martian/schema_test.cljc
+++ b/core/test/martian/schema_test.cljc
@@ -133,8 +133,7 @@
                    (schema/coerce-data schema
                                        {:name "Brachiosaurus"
                                         :address {:city "stavanger"}}
-                                       nil
-                                       true))))
+                                       {:use-defaults? true}))))
 
           (testing "adds missing values when there are defaults"
             (is (= {:name "Brachiosaurus"
@@ -142,8 +141,7 @@
                    (schema/coerce-data schema
                                        {:name "Brachiosaurus"
                                         :address {:city nil}}
-                                       nil
-                                       true))))
+                                       {:use-defaults? true}))))
 
           (testing "adds missing keys"
             (is (= {:name "Brachiosaurus"
@@ -151,8 +149,7 @@
                    (schema/coerce-data schema
                                        {:name "Brachiosaurus"
                                         :address {}}
-                                       nil
-                                       true))))
+                                       {:use-defaults? true}))))
 
           (testing "removing extra keys"
             (is (= {:name "Brachiosaurus"
@@ -161,8 +158,7 @@
                                        {:name "Brachiosaurus"
                                         :extra "key"
                                         :address {}}
-                                       nil
-                                       true))))
+                                       {:use-defaults? true}))))
 
           ;; doesn't work - a limitation of spec-tools?
           #_(testing "works inside arrays"
@@ -173,8 +169,7 @@
                                          {:name "Brachiosaurus"
                                           :address {:city "stavanger"}
                                           :tags [{:k nil}]}
-                                         nil
-                                         true)))))))))
+                                         {:use-defaults? true})))))))))
 
 ;; "int-or-string" (s/cond-pre s/Str s/Int)
 (deftest int-or-string-test
@@ -403,14 +398,15 @@
              (schema/coerce-data {s/Keyword s/Any} data)))))
 
   (testing "deeply nested aliasing"
-    (let [data {:aCamel {:anotherCamel {:camelsEverywhere 1}}}]
+    (let [data {:aCamel {:anotherCamel {:camelsEverywhere 1}}}
+          parameter-aliases {[]                        {:a-camel :aCamel}
+                             [:a-camel]                {:another-camel :anotherCamel}
+                             [:a-camel :another-camel] {:camels-everywhere :camelsEverywhere}}]
       (is (= data
              (schema/coerce-data
-              {s/Keyword s/Any}
-              {:a-camel {:another-camel {:camels-everywhere 1}}}
-              {[] {:a-camel :aCamel}
-               [:a-camel] {:another-camel :anotherCamel}
-               [:a-camel :another-camel] {:camels-everywhere :camelsEverywhere}})))))
+               {s/Keyword s/Any}
+               {:a-camel {:another-camel {:camels-everywhere 1}}}
+               {:parameter-aliases parameter-aliases})))))
 
   (testing "keywords to strings"
     (is (= "foo" (schema/coerce-data s/Str :foo)))))


### PR DESCRIPTION
@oliyh Hello again, Oliver!

This PR addresses a proposal made in #220.

The main part is essentially non-breaking (passing things through existing `:opts` to override the `default-coercion-matcher`), but I've also made a few minor relevant improvements here and there — improved readability/maintainability, exposed some useful schema internals (private -> public), reused `schema-tools` fns, and reordered `core` ns imports.

Thanks for such a neat tool!