### PR TITLE
Add support for 'multipart/form-data' content-type (JVM/Babashka)

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Interceptors provided at a per-route level are inserted into the interceptor cha
   - `route-interceptor-1` e.g. `::override-load-pet-method`
   - `route-interceptor-2`
   - etc
-- `encode-body`
+- `default-encode-request`
 - `default-coerce-response`
 - `perform-request`
 
@@ -360,7 +360,7 @@ You may move or provide your own version of `enqueue-route-specific-interceptors
 
 ## Custom content-types
 
-Martian allows you to add support for content-types in addition to those supported out of the box - `transit`, `edn` and `json`.
+Martian allows you to add support for content-types in addition to those supported out of the box — `transit`, `edn`, `json`, and `multipart` (supported in all JVM/Babashka HTTP clients except for `clj-http-lite`).
 
 ```clojure
 (require '[martian.core :as m])
@@ -379,7 +379,7 @@ Martian allows you to add support for content-types in addition to those support
   (http/bootstrap-openapi
    "https://example-api.com"
    {:interceptors (concat m/default-interceptors
-                          [(i/encode-body encoders)
+                          [(i/encode-request encoders)
                            (i/coerce-response encoders)
                            http/perform-request])}))
 

--- a/clj-http-lite/src/martian/clj_http_lite.clj
+++ b/clj-http-lite/src/martian/clj_http_lite.clj
@@ -1,11 +1,11 @@
 (ns martian.clj-http-lite
-  (:require [clj-http.lite.client :as http]
-            [cheshire.core :as json]
-            [martian.file :as file]
-            [martian.yaml :as yaml]
+  (:require [cheshire.core :as json]
+            [clj-http.lite.client :as http]
             [martian.core :as martian]
+            [martian.file :as file]
             [martian.interceptors :as interceptors]
-            [martian.openapi :as openapi]))
+            [martian.openapi :as openapi]
+            [martian.yaml :as yaml]))
 
 (defn- prepare-response-headers [headers]
   (reduce (fn [m [k v]] (assoc m (keyword k) v)) {} headers))
@@ -18,7 +18,11 @@
                                      (update-in [:headers] prepare-response-headers))))})
 
 (def default-interceptors
-  (concat martian/default-interceptors [interceptors/default-encode-body interceptors/default-coerce-response perform-request]))
+  (conj martian/default-interceptors
+        ;; clj-http-lite does not support 'multipart/form-data' uploads
+        interceptors/default-encode-body
+        interceptors/default-coerce-response
+        perform-request))
 
 (def default-opts {:interceptors default-interceptors})
 

--- a/clj-http/src/martian/clj_http.clj
+++ b/clj-http/src/martian/clj_http.clj
@@ -1,6 +1,7 @@
 (ns martian.clj-http
   (:require [clj-http.client :as http]
             [martian.core :as martian]
+            [martian.encoders :as encoders]
             [martian.file :as file]
             [martian.interceptors :as interceptors]
             [martian.openapi :as openapi]
@@ -11,8 +12,16 @@
    :leave (fn [{:keys [request] :as ctx}]
             (assoc ctx :response (http/request request)))})
 
+(def encoders
+  (assoc (encoders/default-encoders)
+    "multipart/form-data" {:encode encoders/multipart-encode
+                           :as :multipart}))
+
 (def default-interceptors
-  (concat martian/default-interceptors [interceptors/default-encode-body interceptors/default-coerce-response perform-request]))
+  (conj martian/default-interceptors
+        (interceptors/encode-request encoders)
+        interceptors/default-coerce-response
+        perform-request))
 
 (def default-opts {:interceptors default-interceptors})
 

--- a/core/src/martian/encoders.cljc
+++ b/core/src/martian/encoders.cljc
@@ -35,6 +35,10 @@
      (if-let [v (if-not (string/blank? body) (js/JSON.parse body))]
        (js->clj v :keywordize-keys key-fn))))
 
+#?(:clj
+   (defn multipart-encode [body]
+     (mapv (fn [[k v]] {:name (name k) :content v}) body)))
+
 #?(:cljs
    (defn- form-encode [body]
      (str (js/URLSearchParams. (clj->js body)))))

--- a/core/src/martian/interceptors.cljc
+++ b/core/src/martian/interceptors.cljc
@@ -1,5 +1,6 @@
 (ns martian.interceptors
   (:require [martian.schema :as schema]
+            [clojure.set :as set]
             [clojure.walk :refer [keywordize-keys stringify-keys]]
             [tripod.context :as tc]
             [schema.core :as s]
@@ -82,19 +83,27 @@
               (update ctx ::tc/queue #(into (into tc/queue i) %))
               ctx))})
 
-(defn encode-body [encoders]
-  {:name ::encode-body
+(defn encode-request [encoders]
+  {:name ::encode-request
    :encodes (keys encoders)
    :enter (fn [{:keys [request handler] :as ctx}]
-            (let [content-type (and (:body request)
+            (let [has-body? (get-in ctx [:request :body])
+                  content-type (and has-body?
                                     (not (get-in request [:headers "Content-Type"]))
                                     (encoding/choose-content-type encoders (:consumes handler)))
+                  multipart? (= "multipart/form-data" content-type)
                   {:keys [encode]} (encoding/find-encoder encoders content-type)]
               (cond-> ctx
-                (get-in ctx [:request :body]) (update-in [:request :body] encode)
-                content-type (assoc-in [:request :headers "Content-Type"] content-type))))})
+                      has-body? (update-in [:request :body] encode)
+                      ;; NB: Luckily, all target HTTP clients — clj-http (but not lite), http-kit,
+                      ;;     hato, and even babashka/http-client — all support the same syntax.
+                      multipart? (update :request set/rename-keys {:body :multipart})
+                      content-type (assoc-in [:request :headers "Content-Type"] content-type))))})
 
-(def default-encode-body (encode-body (encoders/default-encoders)))
+(def default-encode-request (encode-request (encoders/default-encoders)))
+
+;; todo left for the backward compatibility - drop later, upon a major version release
+(def default-encode-body default-encode-request)
 
 (defn coerce-response [encoders]
   {:name ::coerce-response

--- a/core/test/martian/interceptors_test.cljc
+++ b/core/test/martian/interceptors_test.cljc
@@ -10,17 +10,17 @@
 #?(:cljs
    (def Throwable js/Error))
 
-(deftest encode-body-test
-  (let [i i/default-encode-body]
+(deftest encode-request-test
+  (let [i i/default-encode-request]
 
     #?(:bb nil
        :default
        (testing "simple encoders"
-	 (let [body {:the "wheels"
+         (let [body {:the "wheels"
                      :on "the"
                      :bus ["go" "round" "and" "round"]}]
            (testing "form"
-             (is (= {:body #?(:clj "the=wheels&on=the&bus=go&bus=round&bus=and&bus=round"
+             (is (= {:body #?(:clj  "the=wheels&on=the&bus=go&bus=round&bus=and&bus=round"
                               :cljs "the=wheels&on=the&bus=go%2Cround%2Cand%2Cround")
                      :headers {"Content-Type" "application/x-www-form-urlencoded"}}
                     (:request ((:enter i) {:request {:body body}
@@ -48,8 +48,8 @@
                    (-> ((:enter i) {:request {:body body}
                                     :handler {:consumes ["application/transit+json"]}})
                        :request
-                       (update :body #?(:clj (comp #(encoders/transit-decode % :json)
-                                                   tu/input-stream->byte-array)
+                       (update :body #?(:clj  (comp #(encoders/transit-decode % :json)
+                                                    tu/input-stream->byte-array)
                                         :cljs #(encoders/transit-decode % :json)))))))
 
           #?(:bb nil
@@ -61,7 +61,20 @@
                                        :handler {:consumes ["application/transit+msgpack"]}})
                           :request
                           (update :body (comp #(encoders/transit-decode % :msgpack)
-                                              tu/input-stream->byte-array))))))))))))
+                                              tu/input-stream->byte-array)))))))))
+
+      (testing "multipart"
+        (let [body {:alpha 12345
+                    :omega "abc"}
+              i (i/encode-request
+                  (assoc (encoders/default-encoders)
+                    "multipart/form-data" {:encode encoders/multipart-encode
+                                           :as :multipart}))]
+          (is (= {:multipart [{:name "alpha" :content 12345}
+                              {:name "omega" :content "abc"}]
+                  :headers {"Content-Type" "multipart/form-data"}}
+                 (:request ((:enter i) {:request {:body body}
+                                        :handler {:consumes ["multipart/form-data"]}})))))))))
 
 (defn- stub-response [content-type body]
   {:name ::stub-response
@@ -125,7 +138,7 @@
           ctx (tc/enqueue* {:request {:body body}
                               :handler {:consumes ["text/magical+json"]
                                         :produces ["text/magical+json"]}}
-                             [(i/encode-body encoders)
+                             [(i/encode-request encoders)
                               (i/coerce-response encoders)
                               (stub-response "text/magical+json" encoded-body)])
           result (tc/execute ctx)]
@@ -151,7 +164,7 @@
                                                   "Accept" "text/magical+json"}}
                               :handler {:consumes ["text/magical+json"]
                                         :produces ["text/magical+json"]}}
-                             [i/default-encode-body
+                             [i/default-encode-request
                               i/default-coerce-response
                               (stub-response "text/magical+json" encoded-body)])
           result (tc/execute ctx)]
@@ -168,7 +181,7 @@
 
 (deftest supported-content-types-test
   (testing "picks up the supported content-types from the encoding/decoding interceptors"
-    (let [encode-body i/default-encode-body
+    (let [encode-request i/default-encode-request
           coerce-response (i/coerce-response (assoc (encoders/default-encoders)
                                                     "text/magical+json" {:encode encoders/json-encode
                                                                          :decode #(encoders/json-decode % keyword)
@@ -180,7 +193,7 @@
               :decodes #?(:bb #{"application/json" "text/magical+json" "application/transit+msgpack" "application/transit+json" "application/edn"}
                           :clj #{"application/json" "text/magical+json" "application/transit+msgpack" "application/transit+json" "application/edn" "application/x-www-form-urlencoded"}
                           :cljs #{"application/json" "text/magical+json" "application/transit+json" "application/edn" "application/x-www-form-urlencoded"})}
-             (i/supported-content-types [encode-body coerce-response]))))))
+             (i/supported-content-types [encode-request coerce-response]))))))
 
 (deftest validate-response-test
   (let [handler {:response-schemas [{:status (s/eq 200),

--- a/test/src/martian/test.cljc
+++ b/test/src/martian/test.cljc
@@ -106,7 +106,7 @@
                          responder
                          %))
                  (remove (comp (set (keys http-interceptors)) namespace :name))
-                 (remove (comp #{::interceptors/encode-body ::interceptors/coerce-response} :name))))))
+                 (remove (comp #{::interceptors/encode-response ::interceptors/coerce-response} :name))))))
 
 (defn respond-with
   "Adds an interceptor that simulates the server responding with the supplied response.


### PR DESCRIPTION
@oliyh  Hi Oliver!

Here's another itch I had to scratch recently. 😅 

This one is tiny and straightforward — it adds support for `:multipart` requests for all target JVM/Babashka HTTP clients that support this content-type (basically, all except `clj-http-lite`).

The change is backward compatible:
- I didn't drop the original `default-encode-body` fn — it's now effectively an alias for the `default-encode-response`
- As I have not changed the main path in the work of the `encode-response` (ex-`encode-body`)
- Custom end user interceptors will still override the default ones with a user-specific "multipart/form-data" encoder

Hope this one as well helps! Please, tell me if I am missing something important and not that obvious.

Cheers,
Mark