### PR TITLE
Improve on test module

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Martian will assert that you provide the right parameters to the call, and `mart
 generated from the response schema of the remote application. This gives you more confidence that your integration is
 correct without maintenance of a stub.
 
-The following example shows how exceptions will be thrown by bad code and how responses can be generated:
+The following example shows how exceptions will be thrown by bad code and how responses can be generated using the `martian-test/respond-with-generated` function:
 ```clojure
 (require '[martian.core :as martian]
          '[martian.httpkit :as martian-http]
@@ -201,28 +201,28 @@ previously untestable code testable again.
 
 All other non-generative testing approaches and techniques, such a mocks, stubs, and spies, are also supported.
 
-The following example shows how mock responses can be created with `martian-test` facilities:
+The following example shows how mock responses can be created using the `martian-test/respond-with` function:
 ```clojure
 (require '[martian.core :as martian]
          '[martian.httpkit :as martian-http]
          '[martian.test :as martian-test])
 
 (let [m (-> (martian-http/bootstrap-openapi "https://pedestal-api.oliy.co.uk/swagger.json")
-            (martian-test/respond-with-constant {:get-pet {:name "Fedor Mikhailovich" :type "Cat" :age 3}}))]
+            (martian-test/respond-with {:get-pet {:name "Fedor Mikhailovich" :type "Cat" :age 3}}))]
 
   (martian/response-for m :get-pet {:id 123}))
-  ;; => {:status 200, :body {:name "Fedya" :type "Cat" :age 3}}
+  ;; => {:status 200, :body {:name "Fedor Mikhailovich" :type "Cat" :age 3}}
 
 (let [m (-> (martian-http/bootstrap-openapi "https://pedestal-api.oliy.co.uk/swagger.json")
-            (martian-test/respond-with-constant {:get-pet (fn [_request]
-                                                            (let [rand-age (inc (rand-int 50))
-                                                                  ret-cat? (even? rand-age)]
-                                                              {:name (if ret-cat? "Fedor Mikhailovich" "Doggy McDogFace")
-                                                               :type (if ret-cat? "Cat" "Dog")
-                                                               :age  rand-age}))}))]
+            (martian-test/respond-with {:get-pet (fn [_request]
+                                                   (let [rand-age (inc (rand-int 50))
+                                                         ret-cat? (even? rand-age)]
+                                                     {:name (if ret-cat? "Fedor Mikhailovich" "Doggy McDogFace")
+                                                      :type (if ret-cat? "Cat" "Dog")
+                                                      :age rand-age}))}))]
 
   (martian/response-for m :get-pet {:id 123})
-  ;; => {:status 200, :body {:name "Fedya" :type "Cat" :age 13}}
+  ;; => {:status 200, :body {:name "Fedor Mikhailovich" :type "Cat" :age 12}}
 
   (martian/response-for m :get-pet {:id 123})
   ;; => {:status 200, :body {:name "Doggy McDogFace" :type "Dog" :age 7}}

--- a/README.md
+++ b/README.md
@@ -165,8 +165,10 @@ Here's an example:
 
 ## Testing with martian-test
 
-Testing code that calls external systems can be tricky - you either build often elaborate stubs which start
-to become as complex as the system you are calling, or else you ignore it all together with `(constantly true)`.
+Testing code that calls external systems can be tricky — you either build often elaborate stubs which start to become
+as complex as the system you are calling, or else you ignore it all together with `(constantly true)`.
+
+### Generative testing
 
 Martian will assert that you provide the right parameters to the call, and `martian-test` will return a response
 generated from the response schema of the remote application. This gives you more confidence that your integration is
@@ -189,11 +191,44 @@ The following example shows how exceptions will be thrown by bad code and how re
 
   (martian/response-for m :get-pet {:id 123}))
   ;; => {:status 200, :body {:id -3, :name "EcLR"}}
-
 ```
-`martian-test` has interceptors that always give successful responses, always errors, or a random choice.
+
+`martian-test` has generative interceptors that always give successful responses, always errors, or a random choice.
 By making your application code accept a Martian instance you can inject a test instance within your tests, making
 previously untestable code testable again.
+
+### Non-generative testing
+
+All other non-generative testing approaches and techniques, such a mocks, stubs, and spies, are also supported.
+
+The following example shows how mock responses can be created with `martian-test` facilities:
+```clojure
+(require '[martian.core :as martian]
+         '[martian.httpkit :as martian-http]
+         '[martian.test :as martian-test])
+
+(let [m (-> (martian-http/bootstrap-openapi "https://pedestal-api.oliy.co.uk/swagger.json")
+            (martian-test/respond-with-constant {:get-pet {:name "Fedor Mikhailovich" :type "Cat" :age 3}}))]
+
+  (martian/response-for m :get-pet {:id 123}))
+  ;; => {:status 200, :body {:name "Fedya" :type "Cat" :age 3}}
+
+(let [m (-> (martian-http/bootstrap-openapi "https://pedestal-api.oliy.co.uk/swagger.json")
+            (martian-test/respond-with-constant {:get-pet (fn [_request]
+                                                            (let [rand-age (inc (rand-int 50))
+                                                                  ret-cat? (even? rand-age)]
+                                                              {:name (if ret-cat? "Fedor Mikhailovich" "Doggy McDogFace")
+                                                               :type (if ret-cat? "Cat" "Dog")
+                                                               :age  rand-age}))}))]
+
+  (martian/response-for m :get-pet {:id 123})
+  ;; => {:status 200, :body {:name "Fedya" :type "Cat" :age 13}}
+
+  (martian/response-for m :get-pet {:id 123})
+  ;; => {:status 200, :body {:name "Doggy McDogFace" :type "Dog" :age 7}}
+
+  ...)
+```
 
 More documentation is available at [martian-test](https://github.com/oliyh/martian/tree/master/test).
 

--- a/test/src/martian/test.cljc
+++ b/test/src/martian/test.cljc
@@ -15,7 +15,7 @@
                         :success (status-range 200 399)
                         :error (status-range 400 599)}
                        response-type)]
-   (filter filter-fn response-schemas)))
+    (filter filter-fn response-schemas)))
 
 (defn- make-generator [response-type response-schemas]
   (some->> response-schemas
@@ -169,11 +169,15 @@
     (throw (ex-info "Unsupported type of responses" {:type (type responses)}))))
 
 (defn respond-with-generated
-  "Adds an interceptor that simulates the server responding to operations by generating responses of the supplied response-type
-   from the handler response schemas.
-   Removes all interceptors that would perform real HTTP operations"
+  "Adds an interceptor that simulates the server responding with responses generated from the handler response schemas.
+
+   The `response-types` maps a `:route-name` to a response type which can be `:random` (default, any HTTP status code),
+   `:success` (HTTP status codes 200-399), or `:error` (HTTP status codes 400-599).
+
+   Removes all interceptors that would perform real HTTP operations."
   [martian response-types]
-  (-> (replace-http-interceptors martian)
+  (-> martian
+      (replace-http-interceptors)
       (update :interceptors concat [(generate-responses response-types)])))
 
 (defn respond-as

--- a/test/src/martian/test.cljc
+++ b/test/src/martian/test.cljc
@@ -113,7 +113,7 @@
         (throw (ex-info "Unsupported HTTP client" {:full-name full-name
                                                    :supported (keys http-interceptors)})))))
 
-(defn- replace-http-interceptors [martian]
+(defn replace-http-interceptors [martian]
   (update martian :interceptors
           (fn [interceptors]
             (->> interceptors

--- a/test/test/martian/test_test.cljc
+++ b/test/test/martian/test_test.cljc
@@ -105,14 +105,6 @@
 
 (deftest simulate-implementation-responses-test
   #?(:clj
-     (testing "hato"
-       (let [m (-> (martian/bootstrap-swagger "https://api.com" swagger-definition)
-                   (martian-test/respond-as :hato)
-                   (martian-test/respond-with-generated {:load-pet :success}))]
-
-         (is (= 200 (:status (martian/response-for m :load-pet {:id 123})))))))
-
-  #?(:clj
      (testing "clj-http"
        (let [m (-> (martian/bootstrap-swagger "https://api.com" swagger-definition)
                    (martian-test/respond-as :clj-http)
@@ -127,6 +119,22 @@
                    (martian-test/respond-with-generated {:load-pet :success}))]
 
          (is (= 200 (:status @(martian/response-for m :load-pet {:id 123})))))))
+
+  #?(:clj
+     (testing "hato"
+       (let [m (-> (martian/bootstrap-swagger "https://api.com" swagger-definition)
+                   (martian-test/respond-as :hato)
+                   (martian-test/respond-with-generated {:load-pet :success}))]
+
+         (is (= 200 (:status (martian/response-for m :load-pet {:id 123})))))))
+
+  #?(:clj
+     (testing "babashka.http-client"
+       (let [m (-> (martian/bootstrap-swagger "https://api.com" swagger-definition)
+                   (martian-test/respond-as :babashka.http-client)
+                   (martian-test/respond-with-generated {:load-pet :success}))]
+
+         (is (= 200 (:status (martian/response-for m :load-pet {:id 123})))))))
 
   #?(:cljs
      (testing "cljs-http"

--- a/test/test/martian/test_test.cljc
+++ b/test/test/martian/test_test.cljc
@@ -76,15 +76,15 @@
 (deftest test-check-test
   (let [m (martian/bootstrap-swagger "https://api.com" swagger-definition)
         p (prop/for-all [response (martian-test/response-generator m :load-pet)]
-                        (let [output (fn-to-test (martian-test/respond-with-constant m {:load-pet response}))]
-                          (if (not= 200 (:status response))
-                            (nil? output)
-                            (not (nil? output)))))]
+            (let [output (fn-to-test (martian-test/respond-with-constant m {:load-pet response}))]
+              (if (not= 200 (:status response))
+                (nil? output)
+                (not (nil? output)))))]
 
     (tct/assert-check (tc/quick-check 100 p))))
 
 (deftest respond-with-constant-test
-  (testing "value"
+  (testing "responding with value"
     (let [m (-> (martian/bootstrap-swagger "https://api.com" swagger-definition)
                 (martian-test/respond-with {:load-pet {:status 200
                                                        :body "constant"}}))]
@@ -93,7 +93,7 @@
               :body "constant"}
              (martian/response-for m :load-pet {:id 123})))))
 
-  (testing "function"
+  (testing "responding via function"
     (let [m (-> (martian/bootstrap-swagger "https://api.com" swagger-definition)
                 (martian-test/respond-with {:load-pet (fn [request]
                                                         {:status 200
@@ -102,6 +102,24 @@
       (is (= {:status 200
               :body {:method :get}}
              (martian/response-for m :load-pet {:id 123}))))))
+
+(deftest respond-with-contextual-test
+  (testing "responding via context"
+    (let [m (-> (martian/bootstrap-swagger "https://api.com" swagger-definition)
+                (martian-test/respond-with (fn [ctx]
+                                             {:status 200
+                                              :body ctx})))
+          response (martian/response-for m :load-pet {:id 123})]
+
+      (is (= 200 (:status response)))
+      (is (= {:path "/pets/:id"
+              :route-name :load-pet}
+             (-> response :body :handler (select-keys [:path :route-name]))))
+      (is (= {:id 123}
+             (-> response :body :params)))
+      (is (= {:method :get
+              :url "https://api.com/pets/123"}
+             (-> response :body :request))))))
 
 (deftest simulate-implementation-responses-test
   #?(:clj


### PR DESCRIPTION
@oliyh Hi Oliver!

There are a few things in the `martian-test` module that I believe require a bit of a facelift.

Firstly, I'd like to [introduce a new testing facility — the `respond-with-contextual`](https://github.com/oliyh/martian/commit/ef832c6060f141530a84fd8b2916441e0c9e4c4d) — which is basically an extension of the existing `respond-with`/`respond-with-constant` fns, so these two are not synonymous any more (so I've carefully added this new feature in a backward-compatible way).

Secondly, I've [added a missing 'babashka.http-client' support](https://github.com/oliyh/martian/commit/873e13f181afa0adceac1833ea0146cf9c538edf) to the `martian.test`. This HTTP client is already supported by the main Martian lib, so it has to be covered here as well.

Finally, I've also improved on public functions' docstrings and updated the Martian documentation.

Cheers,
Mark