### PR TITLE
Fix response coercion issues

### DIFF
--- a/babashka-http-client/src/martian/babashka/http_client.clj
+++ b/babashka-http-client/src/martian/babashka/http_client.clj
@@ -74,7 +74,9 @@
 (def babashka-http-client-interceptors
   (conj martian/default-interceptors
         (interceptors/encode-request request-encoders)
-        interceptors/default-coerce-response
+        (interceptors/coerce-response (encoders/default-encoders)
+                                      {:missing-encoder-as nil
+                                       :default-encoder-as nil})
         keywordize-headers
         default-to-http-1))
 

--- a/babashka-http-client/src/martian/babashka/http_client.clj
+++ b/babashka-http-client/src/martian/babashka/http_client.clj
@@ -100,8 +100,14 @@
 
 (def default-opts {:interceptors default-interceptors})
 
+(defn prepare-opts [{:keys [async?] :as opts}]
+  (merge (if async?
+           {:interceptors default-interceptors-async}
+           default-opts)
+         (dissoc opts :async? :use-client-output-coercion?)))
+
 (defn bootstrap [api-root concise-handlers & [opts]]
-  (martian/bootstrap api-root concise-handlers (merge default-opts opts)))
+  (martian/bootstrap api-root concise-handlers (prepare-opts opts)))
 
 (defn- load-definition [url load-opts]
   (or (file/local-resource url)
@@ -114,6 +120,6 @@
 (defn bootstrap-openapi [url & [{:keys [server-url] :as opts} load-opts]]
   (let [definition (load-definition url load-opts)
         base-url (openapi/base-url url server-url definition)]
-    (martian/bootstrap-openapi base-url definition (merge default-opts opts))))
+    (martian/bootstrap-openapi base-url definition (prepare-opts opts))))
 
 (def bootstrap-swagger bootstrap-openapi)

--- a/babashka-http-client/src/martian/babashka/http_client.clj
+++ b/babashka-http-client/src/martian/babashka/http_client.clj
@@ -19,6 +19,8 @@
     (= :byte-array (:as request))
     (assoc :as :bytes)
 
+    ;; NB: This value is no longer passed by the library itself.
+    ;;     Leaving this clause intact for better compatibility.
     (= :text (:as request))
     (dissoc :as)
 
@@ -99,6 +101,7 @@
       (let [body (:body (http/get url (normalize-request load-opts)))]
         (if (yaml/yaml-url? url)
           (yaml/yaml->edn body)
+          ;; `babashka-http-client` has no support for `:json` response coercion
           (json/read-str body)))))
 
 (defn bootstrap-openapi [url & [{:keys [server-url] :as opts} load-opts]]

--- a/babashka-http-client/src/martian/babashka/http_client.clj
+++ b/babashka-http-client/src/martian/babashka/http_client.clj
@@ -71,12 +71,15 @@
   (assoc (encoders/default-encoders)
     "multipart/form-data" {:encode encoders/multipart-encode}))
 
+;; NB: `babashka-http-client` does not support the `:json` response coercion.
+(def response-coerce-opts
+  {:missing-encoder-as nil
+   :default-encoder-as nil})
+
 (def babashka-http-client-interceptors
   (conj martian/default-interceptors
         (interceptors/encode-request request-encoders)
-        (interceptors/coerce-response (encoders/default-encoders)
-                                      {:missing-encoder-as nil
-                                       :default-encoder-as nil})
+        (interceptors/coerce-response (encoders/default-encoders) response-coerce-opts)
         keywordize-headers
         default-to-http-1))
 

--- a/babashka-http-client/test/martian/babashka/http_client_test.clj
+++ b/babashka-http-client/test/martian/babashka/http_client_test.clj
@@ -87,7 +87,7 @@
              (:body response))))))
 
 (deftest async-test
-  (let [m (martian-http/bootstrap-swagger swagger-url {:interceptors martian-http/default-interceptors-async})]
+  (let [m (martian-http/bootstrap-swagger swagger-url {:async? true})]
     (testing "default encoders"
       (is (= (if-bb
                {:method :post

--- a/babashka-http-client/test/martian/babashka/http_client_test.clj
+++ b/babashka-http-client/test/martian/babashka/http_client_test.clj
@@ -315,3 +315,15 @@
                  :body {:content-type multipart+boundary?
                         :content-map {:custom (str int-num)}}}
                 (martian/response-for m :upload-data {:custom int-num}))))))))
+
+(deftest issue-189-test
+  (testing "operation with '*/*' response content type"
+    (let [m (martian-http/bootstrap-openapi openapi-url {:server-url "http://localhost:8888"})]
+      (is (match?
+            {:method :get
+             :url "http://localhost:8888/issue/189"}
+            (martian/request-for m :get-something {})))
+      (is (match?
+            {:status 200
+             :body {:message "Here's some JSON content"}}
+            (martian/response-for m :get-something {}))))))

--- a/babashka-http-client/test/martian/babashka/http_client_test.clj
+++ b/babashka-http-client/test/martian/babashka/http_client_test.clj
@@ -321,7 +321,6 @@
                         :content-map {:custom (str int-num)}}}
                 (martian/response-for m :upload-data {:custom int-num}))))))))
 
-;; TODO: Fails for BB! The "application/transit+msgpack" sneaks into!
 (deftest supported-content-types-test
   (let [m (martian-http/bootstrap-openapi openapi-url)]
     (if-bb

--- a/babashka-http-client/test/martian/babashka/http_client_test.clj
+++ b/babashka-http-client/test/martian/babashka/http_client_test.clj
@@ -26,7 +26,8 @@
     (def openapi-test-url (format "http://localhost:%s/openapi-test.json" port))
     (def openapi-test-yaml-url (format "http://localhost:%s/openapi-test.yaml" port))
     (def openapi-multipart-url (format "http://localhost:%s/openapi-multipart.json" port))
-    (def test-multipart-file-url (format "http://localhost:%s/test-multipart.txt" port)))
+    (def test-multipart-file-url (format "http://localhost:%s/test-multipart.txt" port))
+    (def openapi-coercions-url (format "http://localhost:%s/openapi-coercions.json" port)))
   (do
     (require '[martian.server-stub :refer [swagger-url
                                            openapi-url
@@ -35,6 +36,7 @@
                                            openapi-test-yaml-url
                                            openapi-multipart-url
                                            test-multipart-file-url
+                                           openapi-coercions-url
                                            with-server]])
     (require '[martian.test-utils :refer [extend-io-factory-for-path]])
     (use-fixtures :once with-server)))
@@ -318,7 +320,7 @@
 
 (deftest issue-189-test
   (testing "operation with '*/*' response content type"
-    (let [m (martian-http/bootstrap-openapi openapi-url {:server-url "http://localhost:8888"})]
+    (let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
       (is (match?
             {:method :get
              :url "http://localhost:8888/issue/189"}

--- a/babashka-http-client/test/martian/babashka/http_client_test.clj
+++ b/babashka-http-client/test/martian/babashka/http_client_test.clj
@@ -15,6 +15,7 @@
                                         input-stream->byte-array
                                         without-content-type?
                                         multipart+boundary?]]
+            [matcher-combinators.matchers :as m]
             [matcher-combinators.test])
   (:import (java.io PrintWriter)
            (java.net Socket URI)))
@@ -60,7 +61,6 @@
                 :body {:name "Doggy McDogFace", :type "Dog", :age 3}
                 :headers {"Accept" "application/transit+json"
                           "Content-Type" "application/transit+json"}
-                :as :text
                 :version :http-1.1}
 
                {:method :post
@@ -98,7 +98,6 @@
                 :body {:name "Doggy McDogFace", :type "Dog", :age 3}
                 :headers {"Accept" "application/transit+json"
                           "Content-Type" "application/transit+json"}
-                :as :text
                 :version :http-1.1}
 
                {:method :post
@@ -356,7 +355,7 @@
     (testing "application/edn"
       (is (match?
             {:headers {"Accept" "application/edn"}
-             :as :text}
+             :as m/absent}
             (martian/request-for m :get-edn)))
       (is (match?
             {:status 200
@@ -366,7 +365,7 @@
     (testing "application/json"
       (is (match?
             {:headers {"Accept" "application/json"}
-             :as :text}
+             :as m/absent}
             (martian/request-for m :get-json)))
       (is (match?
             {:status 200
@@ -376,7 +375,7 @@
     (testing "application/transit+json"
       (is (match?
             {:headers {"Accept" "application/transit+json"}
-             :as :text}
+             :as m/absent}
             (martian/request-for m :get-transit+json)))
       (is (match?
             {:status 200
@@ -403,7 +402,7 @@
       (testing "application/x-www-form-urlencoded"
         (is (match?
               {:headers {"Accept" "application/x-www-form-urlencoded"}
-               :as :text}
+               :as m/absent}
               (martian/request-for m :get-form-data)))
         (is (match?
               {:status 200
@@ -417,7 +416,7 @@
             (martian/handler-for m :get-something)))
       (is (match?
             {:headers {"Accept" "application/json"}
-             :as :text}
+             :as m/absent}
             (martian/request-for m :get-something)))
       (is (match?
             {:status 200
@@ -425,14 +424,13 @@
              :body {:message "Here's some text content"}}
             (martian/response-for m :get-something))))
 
-    ;; TODO: This one fails with "No matching clause: :auto".
     (testing "any response content type (operation with '*/*' content)"
       (is (match?
             {:produces []}
             (martian/handler-for m :get-anything)))
       (let [request (martian/request-for m :get-anything)]
-        #_(is (not (contains? request :as))
-              "The response auto-coercion is NOT set")
+        (is (not (contains? request :as))
+            "The response auto-coercion is NOT set")
         (is (not (contains? (:headers request) "Accept"))
             "The 'Accept' request header is absent"))
       (is (match?

--- a/babashka-http-client/test/martian/babashka/http_client_test.clj
+++ b/babashka-http-client/test/martian/babashka/http_client_test.clj
@@ -12,7 +12,6 @@
                                         binary-content
                                         create-temp-file
                                         input-stream?
-                                        input-stream->byte-array
                                         without-content-type?
                                         multipart+boundary?]]
             [matcher-combinators.matchers :as m]
@@ -47,9 +46,7 @@
   "The `transit+msgpack` is not available when running in BB, but is available
    when running on the JVM"
   [body]
-  (if-bb
-    (encoders/transit-decode (input-stream->byte-array body) :json)
-    (encoders/transit-decode (input-stream->byte-array body) :msgpack)))
+  (encoders/transit-decode body (if-bb :json :msgpack)))
 
 (deftest swagger-http-test
   (let [m (martian-http/bootstrap-swagger swagger-url)]

--- a/babashka-http-client/test/martian/babashka/http_client_test.clj
+++ b/babashka-http-client/test/martian/babashka/http_client_test.clj
@@ -324,25 +324,25 @@
 (deftest supported-content-types-test
   (let [m (martian-http/bootstrap-openapi openapi-url)]
     (if-bb
-      (is (= {:encodes #{"application/transit+json"
-                         "application/json"
-                         "application/edn"
-                         "multipart/form-data"}
-              :decodes #{"application/transit+json"
-                         "application/json"
-                         "application/edn"}}
+      (is (= {:encodes ["application/transit+json"
+                        "application/edn"
+                        "application/json"
+                        "multipart/form-data"]
+              :decodes ["application/transit+json"
+                        "application/edn"
+                        "application/json"]}
              (i/supported-content-types (:interceptors m))))
-      (is (= {:encodes #{"application/transit+msgpack"
-                         "application/transit+json"
-                         "application/json"
-                         "application/edn"
-                         "application/x-www-form-urlencoded"
-                         "multipart/form-data"}
-              :decodes #{"application/transit+msgpack"
-                         "application/transit+json"
-                         "application/json"
-                         "application/edn"
-                         "application/x-www-form-urlencoded"}}
+      (is (= {:encodes ["application/transit+msgpack"
+                        "application/transit+json"
+                        "application/edn"
+                        "application/json"
+                        "application/x-www-form-urlencoded"
+                        "multipart/form-data"]
+              :decodes ["application/transit+msgpack"
+                        "application/transit+json"
+                        "application/edn"
+                        "application/json"
+                        "application/x-www-form-urlencoded"]}
              (i/supported-content-types (:interceptors m)))))))
 
 (deftest response-coercion-test
@@ -409,15 +409,15 @@
 
     (testing "multiple response content types (default encoders order)"
       (is (match?
-            {:produces ["application/json"]}
+            {:produces ["application/transit+json"]}
             (martian/handler-for m :get-something)))
       (is (match?
-            {:headers {"Accept" "application/json"}
+            {:headers {"Accept" "application/transit+json"}
              :as m/absent}
             (martian/request-for m :get-something)))
       (is (match?
             {:status 200
-             :headers {:content-type "application/json;charset=utf-8"}
+             :headers {:content-type "application/transit+json;charset=UTF-8"}
              :body {:message "Here's some text content"}}
             (martian/response-for m :get-something))))
 

--- a/babashka-http-client/test/martian/babashka/http_client_test.clj
+++ b/babashka-http-client/test/martian/babashka/http_client_test.clj
@@ -68,7 +68,7 @@
                 :body {:name "Doggy McDogFace", :type "Dog", :age 3}
                 :headers {"Accept" "application/transit+msgpack"
                           "Content-Type" "application/transit+msgpack"}
-                :as :byte-array
+                :as :bytes
                 :version :http-1.1})
 
              (-> (martian/request-for m :create-pet {:pet {:name "Doggy McDogFace"
@@ -105,7 +105,7 @@
                 :body {:name "Doggy McDogFace", :type "Dog", :age 3}
                 :headers {"Accept" "application/transit+msgpack"
                           "Content-Type" "application/transit+msgpack"}
-                :as :byte-array
+                :as :bytes
                 :version :http-1.1})
              (-> (martian/request-for m :create-pet {:pet {:name "Doggy McDogFace"
                                                            :type "Dog"
@@ -346,8 +346,6 @@
                          "application/x-www-form-urlencoded"}}
              (i/supported-content-types (:interceptors m)))))))
 
-;; TODO: The `:as` values `:text` and `:byte-array` are invalid for this client.
-
 (deftest response-coercion-test
   (let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
     (is (= "http://localhost:8888" (:api-root m)))
@@ -388,7 +386,7 @@
       (testing "application/transit+msgpack"
         (is (match?
               {:headers {"Accept" "application/transit+msgpack"}
-               :as :byte-array}
+               :as :bytes}
               (martian/request-for m :get-transit+msgpack))
             "The 'application/transit+msgpack' has a custom `:as` value set")
         (is (match?

--- a/clj-http-lite/project.clj
+++ b/clj-http-lite/project.clj
@@ -18,4 +18,4 @@
                                   [io.pedestal/pedestal.service "0.5.9"]
                                   [io.pedestal/pedestal.jetty "0.5.9"]
 
-                                  [nubank/matcher-combinators "3.8.5"]]}})
+                                  [nubank/matcher-combinators "3.9.1"]]}})

--- a/clj-http-lite/src/martian/clj_http_lite.clj
+++ b/clj-http-lite/src/martian/clj_http_lite.clj
@@ -2,7 +2,6 @@
   (:require [cheshire.core :as json]
             [clj-http.lite.client :as http]
             [martian.core :as martian]
-            [martian.encoders :as encoders]
             [martian.file :as file]
             [martian.interceptors :as interceptors]
             [martian.openapi :as openapi]
@@ -22,8 +21,8 @@
   (conj martian/default-interceptors
         ;; `clj-http-lite` does not support 'multipart/form-data' uploads
         interceptors/default-encode-body
-        (interceptors/coerce-response (encoders/default-encoders)
-                                      {:delegate-on-missing? false})
+        ;; `clj-http-lite` does not support the `:json` response coercion
+        interceptors/default-coerce-response
         perform-request))
 
 (def default-opts {:interceptors default-interceptors})

--- a/clj-http-lite/test/martian/clj_http_lite_test.clj
+++ b/clj-http-lite/test/martian/clj_http_lite_test.clj
@@ -10,7 +10,6 @@
                                          openapi-test-yaml-url
                                          openapi-coercions-url
                                          with-server]]
-            [martian.test-utils :refer [input-stream->byte-array]]
             [matcher-combinators.test]))
 
 (use-fixtures :once with-server)
@@ -27,7 +26,7 @@
              (-> (martian/request-for m :create-pet {:pet {:name "Doggy McDogFace"
                                                            :type "Dog"
                                                            :age 3}})
-                 (update :body #(encoders/transit-decode (input-stream->byte-array %) :msgpack))))))
+                 (update :body #(encoders/transit-decode % :msgpack))))))
 
     (let [response (martian/response-for m :create-pet {:pet {:name "Doggy McDogFace"
                                                               :type "Dog"

--- a/clj-http-lite/test/martian/clj_http_lite_test.clj
+++ b/clj-http-lite/test/martian/clj_http_lite_test.clj
@@ -8,6 +8,7 @@
                                          openapi-test-url
                                          openapi-yaml-url
                                          openapi-test-yaml-url
+                                         openapi-coercions-url
                                          with-server]]
             [martian.test-utils :refer [input-stream->byte-array]]
             [matcher-combinators.test]))
@@ -81,7 +82,7 @@
 
 (deftest issue-189-test
   (testing "operation with '*/*' response content type"
-    (let [m (martian-http/bootstrap-openapi openapi-url {:server-url "http://localhost:8888"})]
+    (let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
       (is (match?
             {:method :get
              :url "http://localhost:8888/issue/189"

--- a/clj-http-lite/test/martian/clj_http_lite_test.clj
+++ b/clj-http-lite/test/martian/clj_http_lite_test.clj
@@ -10,6 +10,7 @@
                                          openapi-test-yaml-url
                                          openapi-coercions-url
                                          with-server]]
+            [matcher-combinators.matchers :as m]
             [matcher-combinators.test]))
 
 (use-fixtures :once with-server)
@@ -17,29 +18,27 @@
 (deftest swagger-http-test
   (let [m (martian-http/bootstrap-swagger swagger-url)]
     (testing "default encoders"
-      (is (= {:method :post
-              :url "http://localhost:8888/pets/"
-              :body {:name "Doggy McDogFace", :type "Dog", :age 3}
-              :headers {"Accept" "application/transit+msgpack"
-                        "Content-Type" "application/transit+msgpack"}
-              :as :byte-array}
-             (-> (martian/request-for m :create-pet {:pet {:name "Doggy McDogFace"
-                                                           :type "Dog"
-                                                           :age 3}})
-                 (update :body #(encoders/transit-decode % :msgpack))))))
-
-    (let [response (martian/response-for m :create-pet {:pet {:name "Doggy McDogFace"
-                                                              :type "Dog"
-                                                              :age 3}})]
-      (is (= {:status 201
-              :body {:id 123}}
-             (select-keys response [:status :body]))))
-
-    (let [response (martian/response-for m :get-pet {:id 123})]
-      (is (= {:name "Doggy McDogFace"
-              :type "Dog"
-              :age 3}
-             (:body response))))))
+      (is (match?
+            {:body (m/via #(encoders/transit-decode % :msgpack)
+                          {:name "Doggy McDogFace", :type "Dog", :age 3})
+             :headers {"Accept" "application/transit+msgpack"
+                       "Content-Type" "application/transit+msgpack"}
+             :as :byte-array}
+            (martian/request-for m :create-pet {:pet {:name "Doggy McDogFace"
+                                                      :type "Dog"
+                                                      :age 3}}))))
+    (testing "server responses"
+      (is (match?
+            {:status 201
+             :body {:id 123}}
+            (martian/response-for m :create-pet {:pet {:name "Doggy McDogFace"
+                                                       :type "Dog"
+                                                       :age 3}})))
+      (is (match?
+            {:body {:name "Doggy McDogFace"
+                    :type "Dog"
+                    :age 3}}
+            (martian/response-for m :get-pet {:id 123}))))))
 
 (deftest openapi-bootstrap-test
   (let [m (martian-http/bootstrap-openapi openapi-url)

--- a/clj-http-lite/test/martian/clj_http_lite_test.clj
+++ b/clj-http-lite/test/martian/clj_http_lite_test.clj
@@ -80,8 +80,6 @@
     (is (= [[:list-items "Gets a list of items."]]
            (martian/explore m)))))
 
-;; TODO: The `:as` value `:text` is an improper (yet valid) one for this client.
-
 (deftest response-coercion-test
   (let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
     (is (= "http://localhost:8888" (:api-root m)))
@@ -89,7 +87,7 @@
     (testing "application/edn"
       (is (match?
             {:headers {"Accept" "application/edn"}
-             :as :text}
+             :as :string}
             (martian/request-for m :get-edn)))
       (is (match?
             {:status 200
@@ -99,7 +97,7 @@
     (testing "application/json"
       (is (match?
             {:headers {"Accept" "application/json"}
-             :as :text}
+             :as :string}
             (martian/request-for m :get-json)))
       (is (match?
             {:status 200
@@ -109,7 +107,7 @@
     (testing "application/transit+json"
       (is (match?
             {:headers {"Accept" "application/transit+json"}
-             :as :text}
+             :as :string}
             (martian/request-for m :get-transit+json)))
       (is (match?
             {:status 200
@@ -130,7 +128,7 @@
     (testing "application/x-www-form-urlencoded"
       (is (match?
             {:headers {"Accept" "application/x-www-form-urlencoded"}
-             :as :text}
+             :as :string}
             (martian/request-for m :get-form-data)))
       (is (match?
             {:status 200
@@ -144,7 +142,7 @@
             (martian/handler-for m :get-something)))
       (is (match?
             {:headers {"Accept" "application/json"}
-             :as :text}
+             :as :string}
             (martian/request-for m :get-something)))
       (is (match?
             {:status 200

--- a/clj-http-lite/test/martian/clj_http_lite_test.clj
+++ b/clj-http-lite/test/martian/clj_http_lite_test.clj
@@ -80,15 +80,89 @@
     (is (= [[:list-items "Gets a list of items."]]
            (martian/explore m)))))
 
-(deftest issue-189-test
-  (testing "operation with '*/*' response content type"
-    (let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
+;; TODO: The `:as` value `:text` is an improper (yet valid) one for this client.
+
+(deftest response-coercion-test
+  (let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
+    (is (= "http://localhost:8888" (:api-root m)))
+
+    (testing "application/edn"
       (is (match?
-            {:method :get
-             :url "http://localhost:8888/issue/189"
-             :as :auto}
-            (martian/request-for m :get-something {})))
+            {:headers {"Accept" "application/edn"}
+             :as :text}
+            (martian/request-for m :get-edn)))
       (is (match?
             {:status 200
-             :body {:message "Here's some JSON content"}}
-            (martian/response-for m :get-something {}))))))
+             :headers {:content-type "application/edn;charset=UTF-8"}
+             :body {:message "Here's some text content"}}
+            (martian/response-for m :get-edn))))
+    (testing "application/json"
+      (is (match?
+            {:headers {"Accept" "application/json"}
+             :as :text}
+            (martian/request-for m :get-json)))
+      (is (match?
+            {:status 200
+             :headers {:content-type "application/json;charset=utf-8"}
+             :body {:message "Here's some text content"}}
+            (martian/response-for m :get-json))))
+    (testing "application/transit+json"
+      (is (match?
+            {:headers {"Accept" "application/transit+json"}
+             :as :text}
+            (martian/request-for m :get-transit+json)))
+      (is (match?
+            {:status 200
+             :headers {:content-type "application/transit+json;charset=UTF-8"}
+             :body {:message "Here's some text content"}}
+            (martian/response-for m :get-transit+json))))
+    (testing "application/transit+msgpack"
+      (is (match?
+            {:headers {"Accept" "application/transit+msgpack"}
+             :as :byte-array}
+            (martian/request-for m :get-transit+msgpack))
+          "The 'application/transit+msgpack' has a custom `:as` value set")
+      (is (match?
+            {:status 200
+             :headers {:content-type "application/transit+msgpack;charset=UTF-8"}
+             :body {:message "Here's some text content"}}
+            (martian/response-for m :get-transit+msgpack))))
+    (testing "application/x-www-form-urlencoded"
+      (is (match?
+            {:headers {"Accept" "application/x-www-form-urlencoded"}
+             :as :text}
+            (martian/request-for m :get-form-data)))
+      (is (match?
+            {:status 200
+             :headers {:content-type "application/x-www-form-urlencoded"}
+             :body {:message "Here's some text content"}}
+            (martian/response-for m :get-form-data))))
+
+    (testing "multiple response content types (default encoders order)"
+      (is (match?
+            {:produces ["application/json"]}
+            (martian/handler-for m :get-something)))
+      (is (match?
+            {:headers {"Accept" "application/json"}
+             :as :text}
+            (martian/request-for m :get-something)))
+      (is (match?
+            {:status 200
+             :headers {:content-type "application/json;charset=utf-8"}
+             :body {:message "Here's some text content"}}
+            (martian/response-for m :get-something))))
+
+    (testing "any response content type (operation with '*/*' content)"
+      (is (match?
+            {:produces []}
+            (martian/handler-for m :get-anything)))
+      (let [request (martian/request-for m :get-anything)]
+        (is (= :auto (:as request))
+            "The response auto-coercion is set")
+        (is (not (contains? (:headers request) "Accept"))
+            "The 'Accept' request header is absent"))
+      (is (match?
+            {:status 200
+             :headers {:content-type "application/json;charset=utf-8"}
+             :body {:message "Here's some text content"}}
+            (martian/response-for m :get-anything))))))

--- a/clj-http-lite/test/martian/clj_http_lite_test.clj
+++ b/clj-http-lite/test/martian/clj_http_lite_test.clj
@@ -138,15 +138,15 @@
 
     (testing "multiple response content types (default encoders order)"
       (is (match?
-            {:produces ["application/json"]}
+            {:produces ["application/transit+json"]}
             (martian/handler-for m :get-something)))
       (is (match?
-            {:headers {"Accept" "application/json"}
+            {:headers {"Accept" "application/transit+json"}
              :as :string}
             (martian/request-for m :get-something)))
       (is (match?
             {:status 200
-             :headers {:content-type "application/json;charset=utf-8"}
+             :headers {:content-type "application/transit+json;charset=UTF-8"}
              :body {:message "Here's some text content"}}
             (martian/response-for m :get-something))))
 

--- a/clj-http/src/martian/clj_http.clj
+++ b/clj-http/src/martian/clj_http.clj
@@ -25,13 +25,14 @@
 ;;     we could and, actually, should skip decoding some media types.
 ;;     https://github.com/dakrone/clj-http#optional-dependencies
 (def response-coerce-opts
-  {:skip-decoding-for (cond-> #{"application/json"
-                                "application/transit+json"
-                                "application/transit+msgpack"
-                                "application/x-www-form-urlencoded"}
-                              ;; NB: This one may not be available to the end user!
-                              http/edn-enabled? (conj "application/edn"))
-   :default-encoder-as :auto})
+  #_{:skip-decoding-for (cond-> #{"application/json"
+                                  "application/transit+json"
+                                  "application/transit+msgpack"
+                                  "application/x-www-form-urlencoded"}
+                                ;; NB: This one may not be available to the end user!
+                                http/edn-enabled? (conj "application/edn"))
+     :default-encoder-as :auto}
+  {:default-encoder-as :string})
 
 (def default-interceptors
   (conj martian/default-interceptors

--- a/clj-http/src/martian/clj_http.clj
+++ b/clj-http/src/martian/clj_http.clj
@@ -22,28 +22,42 @@
 
 ;; NB: In accordance with the `clj-http`'s Optional Dependencies, which happen
 ;;     to be on the classpath already as the Martian core module dependencies,
-;;     we could and, actually, should skip decoding some media types.
+;;     we could (or, at the very least, should allow to) skip Martian response
+;;     decoding for those media types.
 ;;     https://github.com/dakrone/clj-http#optional-dependencies
-(def response-coerce-opts
-  #_{:skip-decoding-for (cond-> #{"application/json"
+(defn response-coerce-opts [use-client-output-coercion?]
+  (if use-client-output-coercion?
+    {:skip-decoding-for (cond-> #{"application/json"
                                   "application/transit+json"
                                   "application/transit+msgpack"
                                   "application/x-www-form-urlencoded"}
                                 ;; NB: This one may not be available to the end user!
                                 http/edn-enabled? (conj "application/edn"))
      :default-encoder-as :auto}
-  {:default-encoder-as :string})
+    {:default-encoder-as :string}))
 
-(def default-interceptors
+(defn build-default-interceptors [use-client-output-coercion?]
   (conj martian/default-interceptors
         (interceptors/encode-request request-encoders)
-        (interceptors/coerce-response (encoders/default-encoders) response-coerce-opts)
+        (interceptors/coerce-response (encoders/default-encoders)
+                                      (response-coerce-opts use-client-output-coercion?))
         perform-request))
+
+(defn build-default-opts [use-client-output-coercion?]
+  {:interceptors (build-default-interceptors use-client-output-coercion?)})
+
+(def default-interceptors (build-default-interceptors true))
 
 (def default-opts {:interceptors default-interceptors})
 
+(defn prepare-opts [{:keys [use-client-output-coercion?] :as opts}]
+  (merge (if (some? use-client-output-coercion?)
+           (build-default-opts use-client-output-coercion?)
+           default-opts)
+         (dissoc opts :use-client-output-coercion?)))
+
 (defn bootstrap [api-root concise-handlers & [opts]]
-  (martian/bootstrap api-root concise-handlers (merge default-opts opts)))
+  (martian/bootstrap api-root concise-handlers (prepare-opts opts)))
 
 (defn- load-definition [url load-opts]
   (or (file/local-resource url)
@@ -54,6 +68,6 @@
 (defn bootstrap-openapi [url & [{:keys [server-url] :as opts} load-opts]]
   (let [definition (load-definition url load-opts)
         base-url (openapi/base-url url server-url definition)]
-    (martian/bootstrap-openapi base-url definition (merge default-opts opts))))
+    (martian/bootstrap-openapi base-url definition (prepare-opts opts))))
 
 (def bootstrap-swagger bootstrap-openapi)

--- a/clj-http/src/martian/clj_http.clj
+++ b/clj-http/src/martian/clj_http.clj
@@ -20,10 +20,22 @@
   (assoc (encoders/default-encoders)
     "multipart/form-data" {:encode #(encoders/multipart-encode % custom-type?)}))
 
+;; TODO: This actually doesn't work for some reason... Double-check and fix!
+;; NB: In accordance with the `clj-http`'s Optional Dependencies which happen
+;;     to be on the classpath already as the Martian core module dependencies,
+;;     we should skip decoding some media types.
+;;     https://github.com/dakrone/clj-http#optional-dependencies
+(def response-coerce-opts
+  {:skip-decode #{"application/edn"
+                  "application/json"
+                  "application/transit+json"
+                  "application/transit+msgpack"
+                  "application/x-www-form-urlencoded"}})
+
 (def default-interceptors
   (conj martian/default-interceptors
         (interceptors/encode-request request-encoders)
-        interceptors/default-coerce-response
+        (interceptors/coerce-response (encoders/default-encoders) response-coerce-opts)
         perform-request))
 
 (def default-opts {:interceptors default-interceptors})

--- a/clj-http/src/martian/clj_http.clj
+++ b/clj-http/src/martian/clj_http.clj
@@ -46,7 +46,7 @@
 (defn build-default-opts [use-client-output-coercion?]
   {:interceptors (build-default-interceptors use-client-output-coercion?)})
 
-(def default-interceptors (build-default-interceptors true))
+(def default-interceptors (build-default-interceptors false))
 
 (def default-opts {:interceptors default-interceptors})
 

--- a/clj-http/src/martian/clj_http.clj
+++ b/clj-http/src/martian/clj_http.clj
@@ -25,15 +25,13 @@
 ;;     we could and, actually, should skip decoding some media types.
 ;;     https://github.com/dakrone/clj-http#optional-dependencies
 (def response-coerce-opts
-  ;; TODO: It better go through the built-in client coercions, but this change is breaking!
   {:skip-decode (cond-> #{"application/json"
                           "application/transit+json"
                           "application/transit+msgpack"
                           "application/x-www-form-urlencoded"}
                         ;; NB: This one may not be available to the end user!
                         http/edn-enabled? (conj "application/edn"))
-   :default-encoder-as :auto}
-  #_{:default-encoder-as nil})
+   :default-encoder-as :auto})
 
 (def default-interceptors
   (conj martian/default-interceptors

--- a/clj-http/src/martian/clj_http.clj
+++ b/clj-http/src/martian/clj_http.clj
@@ -26,14 +26,14 @@
 ;;     https://github.com/dakrone/clj-http#optional-dependencies
 (def response-coerce-opts
   ;; TODO: It better go through the built-in client coercions, but this change is breaking!
-  #_{:skip-decode (cond-> #{"application/json"
-                            "application/transit+json"
-                            "application/transit+msgpack"
-                            "application/x-www-form-urlencoded"}
-                          ;; NB: This one may not be available to the end user!
-                          http/edn-enabled? (conj "application/edn"))
-     :default-encoder-as :auto}
-  {:default-encoder-as nil})
+  {:skip-decode (cond-> #{"application/json"
+                          "application/transit+json"
+                          "application/transit+msgpack"
+                          "application/x-www-form-urlencoded"}
+                        ;; NB: This one may not be available to the end user!
+                        http/edn-enabled? (conj "application/edn"))
+   :default-encoder-as :auto}
+  #_{:default-encoder-as nil})
 
 (def default-interceptors
   (conj martian/default-interceptors

--- a/clj-http/src/martian/clj_http.clj
+++ b/clj-http/src/martian/clj_http.clj
@@ -25,12 +25,12 @@
 ;;     we could and, actually, should skip decoding some media types.
 ;;     https://github.com/dakrone/clj-http#optional-dependencies
 (def response-coerce-opts
-  {:skip-decode (cond-> #{"application/json"
-                          "application/transit+json"
-                          "application/transit+msgpack"
-                          "application/x-www-form-urlencoded"}
-                        ;; NB: This one may not be available to the end user!
-                        http/edn-enabled? (conj "application/edn"))
+  {:skip-decoding-for (cond-> #{"application/json"
+                                "application/transit+json"
+                                "application/transit+msgpack"
+                                "application/x-www-form-urlencoded"}
+                              ;; NB: This one may not be available to the end user!
+                              http/edn-enabled? (conj "application/edn"))
    :default-encoder-as :auto})
 
 (def default-interceptors

--- a/clj-http/src/martian/clj_http.clj
+++ b/clj-http/src/martian/clj_http.clj
@@ -26,15 +26,16 @@
 ;;     decoding for those media types.
 ;;     https://github.com/dakrone/clj-http#optional-dependencies
 (defn response-coerce-opts [use-client-output-coercion?]
-  (if use-client-output-coercion?
-    {:skip-decoding-for (cond-> #{"application/json"
-                                  "application/transit+json"
-                                  "application/transit+msgpack"
-                                  "application/x-www-form-urlencoded"}
-                                ;; NB: This one may not be available to the end user!
-                                http/edn-enabled? (conj "application/edn"))
-     :default-encoder-as :auto}
-    {:default-encoder-as :string}))
+  (conj {:auto-coercion-pred #{:auto}}
+        (if use-client-output-coercion?
+          {:skip-decoding-for (cond-> #{"application/json"
+                                        "application/transit+json"
+                                        "application/transit+msgpack"
+                                        "application/x-www-form-urlencoded"}
+                                      ;; NB: This one may not be available to the end user!
+                                      http/edn-enabled? (conj "application/edn"))
+           :default-encoder-as :auto}
+          {:default-encoder-as :string})))
 
 (defn build-default-interceptors [use-client-output-coercion?]
   (conj martian/default-interceptors

--- a/clj-http/src/martian/clj_http.clj
+++ b/clj-http/src/martian/clj_http.clj
@@ -20,17 +20,20 @@
   (assoc (encoders/default-encoders)
     "multipart/form-data" {:encode #(encoders/multipart-encode % custom-type?)}))
 
-;; TODO: This actually doesn't work for some reason... Double-check and fix!
-;; NB: In accordance with the `clj-http`'s Optional Dependencies which happen
+;; NB: In accordance with the `clj-http`'s Optional Dependencies, which happen
 ;;     to be on the classpath already as the Martian core module dependencies,
-;;     we should skip decoding some media types.
+;;     we could and, actually, should skip decoding some media types.
 ;;     https://github.com/dakrone/clj-http#optional-dependencies
 (def response-coerce-opts
-  {:skip-decode #{"application/edn"
-                  "application/json"
-                  "application/transit+json"
-                  "application/transit+msgpack"
-                  "application/x-www-form-urlencoded"}})
+  ;; TODO: It better go through the built-in client coercions, but this change is breaking!
+  #_{:skip-decode (cond-> #{"application/json"
+                            "application/transit+json"
+                            "application/transit+msgpack"
+                            "application/x-www-form-urlencoded"}
+                          ;; NB: This one may not be available to the end user!
+                          http/edn-enabled? (conj "application/edn"))
+     :default-encoder-as :auto}
+  {:default-encoder-as nil})
 
 (def default-interceptors
   (conj martian/default-interceptors

--- a/clj-http/test/martian/clj_http_test.clj
+++ b/clj-http/test/martian/clj_http_test.clj
@@ -12,6 +12,7 @@
                                          openapi-test-yaml-url
                                          openapi-multipart-url
                                          test-multipart-file-url
+                                         openapi-coercions-url
                                          with-server]]
             [martian.test-utils :refer [binary-content
                                         create-temp-file
@@ -276,7 +277,7 @@
 
 (deftest issue-189-test
   (testing "operation with '*/*' response content type"
-    (let [m (martian-http/bootstrap-openapi openapi-url {:server-url "http://localhost:8888"})]
+    (let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
       (is (match?
             {:method :get
              :url "http://localhost:8888/issue/189"

--- a/clj-http/test/martian/clj_http_test.clj
+++ b/clj-http/test/martian/clj_http_test.clj
@@ -273,3 +273,16 @@
                  :body {:content-type multipart+boundary?
                         :content-map {:custom (str int-num)}}}
                 (martian/response-for m :upload-data {:custom int-num}))))))))
+
+(deftest issue-189-test
+  (testing "operation with '*/*' response content type"
+    (let [m (martian-http/bootstrap-openapi openapi-url {:server-url "http://localhost:8888"})]
+      (is (match?
+            {:method :get
+             :url "http://localhost:8888/issue/189"
+             :as :auto}
+            (martian/request-for m :get-something {})))
+      (is (match?
+            {:status 200
+             :body {:message "Here's some JSON content"}}
+            (martian/response-for m :get-something {}))))))

--- a/clj-http/test/martian/clj_http_test.clj
+++ b/clj-http/test/martian/clj_http_test.clj
@@ -275,15 +275,90 @@
                         :content-map {:custom (str int-num)}}}
                 (martian/response-for m :upload-data {:custom int-num}))))))))
 
-(deftest issue-189-test
-  (testing "operation with '*/*' response content type"
-    (let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
+;; TODO: The `:as` value `:text` is an improper (yet valid) one for this client.
+
+(deftest response-coercion-test
+  (let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
+    (is (= "http://localhost:8888" (:api-root m)))
+
+    (testing "application/edn"
       (is (match?
-            {:method :get
-             :url "http://localhost:8888/issue/189"
-             :as :auto}
-            (martian/request-for m :get-something {})))
+            {:headers {"Accept" "application/edn"}
+             :as :text}
+            (martian/request-for m :get-edn)))
       (is (match?
             {:status 200
-             :body {:message "Here's some JSON content"}}
-            (martian/response-for m :get-something {}))))))
+             :headers {"Content-Type" "application/edn;charset=UTF-8"}
+             :body {:message "Here's some text content"}}
+            (martian/response-for m :get-edn))))
+    (testing "application/json"
+      (is (match?
+            {:headers {"Accept" "application/json"}
+             :as :text}
+            (martian/request-for m :get-json)))
+      (is (match?
+            {:status 200
+             :headers {"Content-Type" "application/json;charset=utf-8"}
+             :body {:message "Here's some text content"}}
+            (martian/response-for m :get-json))))
+    (testing "application/transit+json"
+      (is (match?
+            {:headers {"Accept" "application/transit+json"}
+             :as :text}
+            (martian/request-for m :get-transit+json)))
+      (is (match?
+            {:status 200
+             :headers {"Content-Type" "application/transit+json;charset=UTF-8"}
+             :body {:message "Here's some text content"}}
+            (martian/response-for m :get-transit+json))))
+    (testing "application/transit+msgpack"
+      (is (match?
+            {:headers {"Accept" "application/transit+msgpack"}
+             :as :byte-array}
+            (martian/request-for m :get-transit+msgpack))
+          "The 'application/transit+msgpack' has a custom `:as` value set")
+      (is (match?
+            {:status 200
+             :headers {"Content-Type" "application/transit+msgpack;charset=UTF-8"}
+             :body {:message "Here's some text content"}}
+            (martian/response-for m :get-transit+msgpack))))
+    (testing "application/x-www-form-urlencoded"
+      (is (match?
+            {:headers {"Accept" "application/x-www-form-urlencoded"}
+             :as :text}
+            (martian/request-for m :get-form-data)))
+      (is (match?
+            {:status 200
+             :headers {"Content-Type" "application/x-www-form-urlencoded"}
+             :body {:message "Here's some text content"}}
+            (martian/response-for m :get-form-data))))
+
+    (testing "multiple response content types (default encoders order)"
+      (is (match?
+            {:produces ["application/json"]}
+            (martian/handler-for m :get-something)))
+      (is (match?
+            {:headers {"Accept" "application/json"}
+             :as :text}
+            (martian/request-for m :get-something)))
+      (is (match?
+            {:status 200
+             :headers {"Content-Type" "application/json;charset=utf-8"}
+             :body {:message "Here's some text content"}}
+            (martian/response-for m :get-something))))
+
+    (testing "any response content type (operation with '*/*' content)"
+      (is (match?
+            {:produces []}
+            (martian/handler-for m :get-anything)))
+      (let [request (martian/request-for m :get-anything)]
+        (is (= :auto (:as request))
+            "The response auto-coercion is set")
+        (is (not (contains? (:headers request) "Accept"))
+            "The 'Accept' request header is absent"))
+      ;; TODO: Fails with "class clojure.lang.PersistentArrayMap cannot be cast to class java.lang.String".
+      (is (match?
+            {:status 200
+             :headers {"Content-Type" "application/json;charset=utf-8"}
+             :body {:message "Here's some text content"}}
+            (martian/response-for m :get-anything))))))

--- a/clj-http/test/martian/clj_http_test.clj
+++ b/clj-http/test/martian/clj_http_test.clj
@@ -275,13 +275,14 @@
                 (martian/response-for m :upload-data {:custom int-num}))))))))
 
 (deftest response-coercion-test
-  (let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
+  (let [m (martian-http/bootstrap-openapi openapi-coercions-url)
+        default-coerce-as (:default-encoder-as martian-http/response-coerce-opts)]
     (is (= "http://localhost:8888" (:api-root m)))
 
     (testing "application/edn"
       (is (match?
             {:headers {"Accept" "application/edn"}
-             :as :auto}
+             :as default-coerce-as}
             (martian/request-for m :get-edn)))
       (is (match?
             {:status 200
@@ -291,7 +292,7 @@
     (testing "application/json"
       (is (match?
             {:headers {"Accept" "application/json"}
-             :as :auto}
+             :as default-coerce-as}
             (martian/request-for m :get-json)))
       (is (match?
             {:status 200
@@ -301,7 +302,7 @@
     (testing "application/transit+json"
       (is (match?
             {:headers {"Accept" "application/transit+json"}
-             :as :auto}
+             :as default-coerce-as}
             (martian/request-for m :get-transit+json)))
       (is (match?
             {:status 200
@@ -322,7 +323,7 @@
     (testing "application/x-www-form-urlencoded"
       (is (match?
             {:headers {"Accept" "application/x-www-form-urlencoded"}
-             :as :auto}
+             :as default-coerce-as}
             (martian/request-for m :get-form-data)))
       (is (match?
             {:status 200
@@ -336,7 +337,7 @@
             (martian/handler-for m :get-something)))
       (is (match?
             {:headers {"Accept" "application/transit+json"}
-             :as :auto}
+             :as default-coerce-as}
             (martian/request-for m :get-something)))
       (is (match?
             {:status 200

--- a/clj-http/test/martian/clj_http_test.clj
+++ b/clj-http/test/martian/clj_http_test.clj
@@ -275,8 +275,6 @@
                         :content-map {:custom (str int-num)}}}
                 (martian/response-for m :upload-data {:custom int-num}))))))))
 
-;; TODO: The `:as` value `:text` is an improper (yet valid) one for this client.
-
 (deftest response-coercion-test
   (let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
     (is (= "http://localhost:8888" (:api-root m)))
@@ -284,7 +282,7 @@
     (testing "application/edn"
       (is (match?
             {:headers {"Accept" "application/edn"}
-             :as :text}
+             :as :auto}
             (martian/request-for m :get-edn)))
       (is (match?
             {:status 200
@@ -294,7 +292,7 @@
     (testing "application/json"
       (is (match?
             {:headers {"Accept" "application/json"}
-             :as :text}
+             :as :auto}
             (martian/request-for m :get-json)))
       (is (match?
             {:status 200
@@ -304,7 +302,7 @@
     (testing "application/transit+json"
       (is (match?
             {:headers {"Accept" "application/transit+json"}
-             :as :text}
+             :as :auto}
             (martian/request-for m :get-transit+json)))
       (is (match?
             {:status 200
@@ -325,7 +323,7 @@
     (testing "application/x-www-form-urlencoded"
       (is (match?
             {:headers {"Accept" "application/x-www-form-urlencoded"}
-             :as :text}
+             :as :auto}
             (martian/request-for m :get-form-data)))
       (is (match?
             {:status 200
@@ -339,7 +337,7 @@
             (martian/handler-for m :get-something)))
       (is (match?
             {:headers {"Accept" "application/json"}
-             :as :text}
+             :as :auto}
             (martian/request-for m :get-something)))
       (is (match?
             {:status 200
@@ -356,7 +354,6 @@
             "The response auto-coercion is set")
         (is (not (contains? (:headers request) "Accept"))
             "The 'Accept' request header is absent"))
-      ;; TODO: Fails with "class clojure.lang.PersistentArrayMap cannot be cast to class java.lang.String".
       (is (match?
             {:status 200
              :headers {"Content-Type" "application/json;charset=utf-8"}

--- a/clj-http/test/martian/clj_http_test.clj
+++ b/clj-http/test/martian/clj_http_test.clj
@@ -333,15 +333,15 @@
 
     (testing "multiple response content types (default encoders order)"
       (is (match?
-            {:produces ["application/json"]}
+            {:produces ["application/transit+json"]}
             (martian/handler-for m :get-something)))
       (is (match?
-            {:headers {"Accept" "application/json"}
+            {:headers {"Accept" "application/transit+json"}
              :as :auto}
             (martian/request-for m :get-something)))
       (is (match?
             {:status 200
-             :headers {"Content-Type" "application/json;charset=utf-8"}
+             :headers {"Content-Type" "application/transit+json;charset=UTF-8"}
              :body {:message "Here's some text content"}}
             (martian/response-for m :get-something))))
 

--- a/clj-http/test/martian/clj_http_test.clj
+++ b/clj-http/test/martian/clj_http_test.clj
@@ -18,7 +18,6 @@
                                         create-temp-file
                                         extend-io-factory-for-path
                                         input-stream?
-                                        input-stream->byte-array
                                         without-content-type?
                                         multipart+boundary?]]
             [matcher-combinators.test])
@@ -43,7 +42,7 @@
              (-> (martian/request-for m :create-pet {:pet {:name "Doggy McDogFace"
                                                            :type "Dog"
                                                            :age 3}})
-                 (update :body #(encoders/transit-decode (input-stream->byte-array %) :msgpack))))))
+                 (update :body #(encoders/transit-decode % :msgpack))))))
 
     (let [response (martian/response-for m :create-pet {:pet {:name "Doggy McDogFace"
                                                               :type "Dog"

--- a/clj-http/test/martian/clj_http_test.clj
+++ b/clj-http/test/martian/clj_http_test.clj
@@ -274,9 +274,12 @@
                         :content-map {:custom (str int-num)}}}
                 (martian/response-for m :upload-data {:custom int-num}))))))))
 
-(deftest response-coercion-test
-  (let [m (martian-http/bootstrap-openapi openapi-coercions-url)
-        default-coerce-as (:default-encoder-as martian-http/response-coerce-opts)]
+(defn do-response-coercion-test
+  [use-client-output-coercion?]
+  (let [m (martian-http/bootstrap-openapi
+            openapi-coercions-url {:use-client-output-coercion? use-client-output-coercion?})
+        default-coerce-as (:default-encoder-as
+                            (martian-http/response-coerce-opts use-client-output-coercion?))]
     (is (= "http://localhost:8888" (:api-root m)))
 
     (testing "application/edn"
@@ -359,3 +362,9 @@
              :headers {"Content-Type" "application/json;charset=utf-8"}
              :body {:message "Here's some text content"}}
             (martian/response-for m :get-anything))))))
+
+(deftest response-coercion-test
+  (testing "without client-specific output coercion"
+    (do-response-coercion-test false))
+  (testing "with client-specific output coercion (:auto)"
+    (do-response-coercion-test true)))

--- a/clj-http/test/martian/clj_http_test.clj
+++ b/clj-http/test/martian/clj_http_test.clj
@@ -20,6 +20,7 @@
                                         input-stream?
                                         without-content-type?
                                         multipart+boundary?]]
+            [matcher-combinators.matchers :as m]
             [matcher-combinators.test])
   (:import (java.io PrintWriter)
            (java.net Socket URI)
@@ -31,31 +32,28 @@
 
 (deftest swagger-http-test
   (let [m (martian-http/bootstrap-swagger swagger-url)]
-
     (testing "default encoders"
-      (is (= {:method :post
-              :url "http://localhost:8888/pets/"
-              :body {:name "Doggy McDogFace", :type "Dog", :age 3}
-              :headers {"Accept" "application/transit+msgpack"
-                        "Content-Type" "application/transit+msgpack"}
-              :as :byte-array}
-             (-> (martian/request-for m :create-pet {:pet {:name "Doggy McDogFace"
-                                                           :type "Dog"
-                                                           :age 3}})
-                 (update :body #(encoders/transit-decode % :msgpack))))))
-
-    (let [response (martian/response-for m :create-pet {:pet {:name "Doggy McDogFace"
-                                                              :type "Dog"
-                                                              :age 3}})]
-      (is (= {:status 201
-              :body {:id 123}}
-             (select-keys response [:status :body]))))
-
-    (let [response (martian/response-for m :get-pet {:id 123})]
-      (is (= {:name "Doggy McDogFace"
-              :type "Dog"
-              :age 3}
-             (:body response))))))
+      (is (match?
+            {:body (m/via #(encoders/transit-decode % :msgpack)
+                          {:name "Doggy McDogFace", :type "Dog", :age 3})
+             :headers {"Accept" "application/transit+msgpack"
+                       "Content-Type" "application/transit+msgpack"}
+             :as :byte-array}
+            (martian/request-for m :create-pet {:pet {:name "Doggy McDogFace"
+                                                      :type "Dog"
+                                                      :age 3}}))))
+    (testing "server responses"
+      (is (match?
+            {:status 201
+             :body {:id 123}}
+            (martian/response-for m :create-pet {:pet {:name "Doggy McDogFace"
+                                                       :type "Dog"
+                                                       :age 3}})))
+      (is (match?
+            {:body {:name "Doggy McDogFace"
+                    :type "Dog"
+                    :age 3}}
+            (martian/response-for m :get-pet {:id 123}))))))
 
 (deftest openapi-bootstrap-test
   (let [m (martian-http/bootstrap-openapi openapi-url)

--- a/cljs-http-promise/project.clj
+++ b/cljs-http-promise/project.clj
@@ -24,6 +24,8 @@
                                   [nrepl/nrepl "1.3.1"]
                                   [cider/piggieback "0.6.0"]
 
+                                  [nubank/matcher-combinators "3.9.1"]
+
                                   [org.eclipse.jetty.websocket/websocket-server "9.4.35.v20201120" :upgrade false]
                                   [org.eclipse.jetty.websocket/websocket-servlet "9.4.35.v20201120" :upgrade false]
                                   [pedestal-api "0.3.5"]

--- a/cljs-http-promise/src/martian/cljs_http_promise.cljs
+++ b/cljs-http-promise/src/martian/cljs_http_promise.cljs
@@ -1,5 +1,6 @@
 (ns martian.cljs-http-promise
-  (:require [cljs-http.client :as http]
+  (:require [cljs-http.client :as http-client]
+            [cljs-http.core :as http]
             [martian.core :as martian]
             [martian.encoders :as encoders]
             [martian.interceptors :as i]
@@ -11,27 +12,44 @@
 (def ^:private go-async
   i/remove-stack)
 
+;; NB: The `cljs-http` by default decodes EDN, JSON, and Transit JSON via mws.
+;;     Martian does the same and more via the `::coerce-response` interceptor.
+(defn wrap-request
+  [request]
+  (-> request
+      http-client/wrap-accept
+      http-client/wrap-form-params
+      http-client/wrap-multipart-params
+      http-client/wrap-edn-params
+      #_http-client/wrap-edn-response
+      http-client/wrap-transit-params
+      #_http-client/wrap-transit-response
+      http-client/wrap-json-params
+      #_http-client/wrap-json-response
+      http-client/wrap-content-type
+      http-client/wrap-query-params
+      http-client/wrap-basic-auth
+      http-client/wrap-oauth
+      http-client/wrap-method
+      http-client/wrap-url
+      http-client/wrap-default-headers))
+
+(def make-request! (wrap-request http/request))
+
 (def perform-request
   {:name ::perform-request
    :leave (fn [{:keys [request] :as ctx}]
             (-> ctx
                 go-async
                 (assoc :response
-                       (prom/then (http/request request)
+                       (prom/then (make-request! request)
                                   (fn [response]
                                     (:response (tc/execute (assoc ctx :response response))))))))})
-
-;; NB: The `cljs-http` by default decodes EDN, JSON, and Transit JSON via mws.
-(def response-encoders
-  (dissoc (encoders/default-encoders)
-          "application/edn"
-          "application/json"
-          "application/transit+json"))
 
 (def default-interceptors
   (conj martian/default-interceptors
         i/default-encode-body
-        (i/coerce-response response-encoders
+        (i/coerce-response (encoders/default-encoders)
                            {:request-key :response-type
                             :missing-encoder-as :default
                             :default-encoder-as :default})
@@ -43,7 +61,7 @@
   (martian/bootstrap api-root concise-handlers (merge default-opts opts)))
 
 (defn bootstrap-openapi [url & [{:keys [server-url trim-base-url?] :as opts} load-opts]]
-  (prom/then (http/get url (merge {:as :json} load-opts))
+  (prom/then (http-client/get url load-opts)
              (fn [response]
                (let [definition (:body response)
                      raw-base-url (openapi/base-url url server-url definition)

--- a/cljs-http-promise/src/martian/cljs_http_promise.cljs
+++ b/cljs-http-promise/src/martian/cljs_http_promise.cljs
@@ -21,13 +21,18 @@
                                   (fn [response]
                                     (:response (tc/execute (assoc ctx :response response))))))))})
 
+(def response-coerce-opts
+  {:skip-decode #{"application/edn"
+                  "application/json"
+                  "application/transit+json"}
+   :request-key :response-type
+   :missing-encoder-as :default
+   :default-encoder-as :default})
+
 (def default-interceptors
   (conj martian/default-interceptors
         i/default-encode-body
-        (i/coerce-response (encoders/default-encoders)
-                           {:request-key :response-type
-                            :missing-encoder-as :default
-                            :default-encoder-as :default})
+        (i/coerce-response (encoders/default-encoders) response-coerce-opts)
         perform-request))
 
 (def default-opts {:interceptors default-interceptors})

--- a/cljs-http-promise/src/martian/cljs_http_promise.cljs
+++ b/cljs-http-promise/src/martian/cljs_http_promise.cljs
@@ -22,9 +22,9 @@
                                     (:response (tc/execute (assoc ctx :response response))))))))})
 
 (def response-coerce-opts
-  {:skip-decode #{"application/edn"
-                  "application/json"
-                  "application/transit+json"}
+  {:skip-decoding-for #{"application/edn"
+                        "application/json"
+                        "application/transit+json"}
    :request-key :response-type
    :missing-encoder-as :default
    ;; NB: This must not be `:text`, since this previous global default value

--- a/cljs-http-promise/src/martian/cljs_http_promise.cljs
+++ b/cljs-http-promise/src/martian/cljs_http_promise.cljs
@@ -1,6 +1,7 @@
 (ns martian.cljs-http-promise
   (:require [cljs-http.client :as http]
             [martian.core :as martian]
+            [martian.encoders :as encoders]
             [martian.interceptors :as i]
             [martian.openapi :as openapi]
             [tripod.context :as tc]
@@ -20,8 +21,21 @@
                                   (fn [response]
                                     (:response (tc/execute (assoc ctx :response response))))))))})
 
+;; NB: The `cljs-http` by default decodes EDN, JSON, and Transit JSON via mws.
+(def response-encoders
+  (dissoc (encoders/default-encoders)
+          "application/edn"
+          "application/json"
+          "application/transit+json"))
+
 (def default-interceptors
-  (concat martian/default-interceptors [i/default-encode-body i/default-coerce-response perform-request]))
+  (conj martian/default-interceptors
+        i/default-encode-body
+        (i/coerce-response response-encoders
+                           {:request-key :response-type
+                            :missing-encoder-as :default
+                            :default-encoder-as :default})
+        perform-request))
 
 (def default-opts {:interceptors default-interceptors})
 

--- a/cljs-http-promise/src/martian/cljs_http_promise.cljs
+++ b/cljs-http-promise/src/martian/cljs_http_promise.cljs
@@ -27,6 +27,9 @@
                   "application/transit+json"}
    :request-key :response-type
    :missing-encoder-as :default
+   ;; NB: This must not be `:text`, since this previous global default value
+   ;;     never actually affected `cljs-http` response coercion due to being
+   ;;     passed under the wrong request key, `:as`.
    :default-encoder-as :default})
 
 (def default-interceptors

--- a/cljs-http-promise/test/martian/cljs_http_promise_test.cljs
+++ b/cljs-http-promise/test/martian/cljs_http_promise_test.cljs
@@ -76,14 +76,14 @@
 (deftest supported-content-types-test
   (async done
     (-> (prom/let [m (martian-http/bootstrap-openapi openapi-url)]
-          (is (= {:encodes #{"application/transit+json"
-                             "application/json"
-                             "application/edn"
-                             "application/x-www-form-urlencoded"}
-                  :decodes #{"application/transit+json"
-                             "application/json"
-                             "application/edn"
-                             "application/x-www-form-urlencoded"}}
+          (is (= {:encodes ["application/transit+json"
+                            "application/edn"
+                            "application/json"
+                            "application/x-www-form-urlencoded"]
+                  :decodes ["application/transit+json"
+                            "application/edn"
+                            "application/json"
+                            "application/x-www-form-urlencoded"]}
                  (i/supported-content-types (:interceptors m)))))
         (prom/catch report-error-and-throw)
         (prom/finally (fn []

--- a/cljs-http-promise/test/martian/cljs_http_promise_test.cljs
+++ b/cljs-http-promise/test/martian/cljs_http_promise_test.cljs
@@ -1,7 +1,8 @@
 (ns martian.cljs-http-promise-test
-  (:require [martian.cljs-http-promise :as martian-http]
+  (:require [cljs.test :refer-macros [async deftest is]]
+            [martian.cljs-http-promise :as martian-http]
             [martian.core :as martian]
-            [cljs.test :refer-macros [deftest is async]]
+            [martian.interceptors :as i]
             [promesa.core :as prom])
   (:require-macros [martian.file :refer [load-local-resource]]))
 
@@ -59,3 +60,18 @@
     (is (= "https://sandbox.example.com" (:api-root m)))
     (is (= [[:list-items "Gets a list of items."]]
            (martian/explore m)))))
+
+(deftest supported-content-types-test
+  (async done
+    (-> (prom/let [m (martian-http/bootstrap-openapi openapi-url)]
+          (is (= {:encodes #{"application/transit+json"
+                             "application/json"
+                             "application/edn"
+                             "application/x-www-form-urlencoded"}
+                  :decodes #{"application/transit+json"
+                             "application/json"
+                             "application/edn"
+                             "application/x-www-form-urlencoded"}}
+                 (i/supported-content-types (:interceptors m)))))
+        (prom/finally (fn []
+                        (done))))))

--- a/cljs-http-promise/test/martian/cljs_http_promise_test.cljs
+++ b/cljs-http-promise/test/martian/cljs_http_promise_test.cljs
@@ -10,6 +10,7 @@
 (def swagger-url "http://localhost:8888/swagger.json")
 (def openapi-url "http://localhost:8888/openapi.json")
 (def openapi-test-url "http://localhost:8888/openapi-test.json")
+(def openapi-coercions-url "http://localhost:8888/openapi-coercions.json")
 
 (defn report-error-and-throw [err]
   (cljs.test/report
@@ -91,7 +92,7 @@
 (deftest issue-189-test
   (async done
     (testing "operation with '*/*' response content type"
-      (-> (prom/let [m (martian-http/bootstrap-openapi openapi-url {:server-url "http://localhost:8888"})
+      (-> (prom/let [m (martian-http/bootstrap-openapi openapi-coercions-url)
                      response (martian/response-for m :get-something {})]
             (is (match?
                   {:method :get

--- a/cljs-http-promise/test/martian/cljs_http_promise_test.cljs
+++ b/cljs-http-promise/test/martian/cljs_http_promise_test.cljs
@@ -1,8 +1,9 @@
 (ns martian.cljs-http-promise-test
-  (:require [cljs.test :refer-macros [async deftest is]]
+  (:require [cljs.test :refer-macros [async deftest is testing]]
             [martian.cljs-http-promise :as martian-http]
             [martian.core :as martian]
             [martian.interceptors :as i]
+            [matcher-combinators.test]
             [promesa.core :as prom])
   (:require-macros [martian.file :refer [load-local-resource]]))
 
@@ -73,5 +74,22 @@
                              "application/edn"
                              "application/x-www-form-urlencoded"}}
                  (i/supported-content-types (:interceptors m)))))
+        (prom/finally (fn []
+                        (done))))))
+
+(deftest issue-189-test
+  (async done
+    (-> (testing "operation with '*/*' response content type"
+          (prom/let [m (martian-http/bootstrap-openapi openapi-url {:server-url "http://localhost:8888"})]
+            (is (match?
+                  {:method :get
+                   :url "http://localhost:8888/issue/189"
+                   :response-type :default}
+                  (martian/request-for m :get-something {})))
+            (prom/let [response (martian/response-for m :get-something {})]
+              (is (match?
+                    {:status 200
+                     :body {:message "Here's some JSON content"}}
+                    response)))))
         (prom/finally (fn []
                         (done))))))

--- a/cljs-http-promise/test/martian/cljs_http_promise_test.cljs
+++ b/cljs-http-promise/test/martian/cljs_http_promise_test.cljs
@@ -89,15 +89,13 @@
         (prom/finally (fn []
                         (done))))))
 
-;; TODO: The `cljs-http` uses `:response-type` request key for output coercion.
-
 (deftest response-coercion-edn-test
   (async done
     (testing "application/edn"
       (-> (prom/let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
             (is (match?
                   {:headers {"Accept" "application/edn"}
-                   #_#_:response-type :default}
+                   :response-type :default}
                   (martian/request-for m :get-edn)))
             (-> (martian/response-for m :get-edn)
                 (prom/then (fn [response]
@@ -116,7 +114,7 @@
       (-> (prom/let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
             (is (match?
                   {:headers {"Accept" "application/json"}
-                   #_#_:response-type :default}
+                   :response-type :default}
                   (martian/request-for m :get-json)))
             (-> (martian/response-for m :get-json)
                 (prom/then (fn [response]
@@ -135,7 +133,7 @@
       (-> (prom/let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
             (is (match?
                   {:headers {"Accept" "application/transit+json"}
-                   #_#_:response-type :default}
+                   :response-type :default}
                   (martian/request-for m :get-transit+json)))
             (-> (martian/response-for m :get-transit+json)
                 (prom/then (fn [response]
@@ -154,16 +152,14 @@
       (-> (prom/let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
             (is (match?
                   {:headers {"Accept" "application/x-www-form-urlencoded"}
-                   #_#_:response-type :default}
+                   :response-type :text}
                   (martian/request-for m :get-form-data)))
             (-> (martian/response-for m :get-form-data)
                 (prom/then (fn [response]
-                             ;; TODO: Fails due to a raw type mismatch (does not apply encoder).
                              (is (match?
                                    {:status 200
                                     :headers {"content-type" "application/x-www-form-urlencoded"}
-                                    :body {:message "Here's some text content"}
-                                    #_"message=Here%27s+some+text+content"}
+                                    :body {:message "Here's some text content"}}
                                    response))))))
           (prom/catch report-error-and-throw)
           (prom/finally (fn []
@@ -178,7 +174,7 @@
                   (martian/handler-for m :get-something)))
             (is (match?
                   {:headers {"Accept" "application/transit+json"}
-                   #_#_:response-type :default}
+                   :response-type :default}
                   (martian/request-for m :get-something)))
             (-> (martian/response-for m :get-something)
                 (prom/then (fn [response]
@@ -199,8 +195,8 @@
                   {:produces []}
                   (martian/handler-for m :get-anything)))
             (let [request (martian/request-for m :get-anything)]
-              #_(is (= :default (:response-type request))
-                    "The response auto-coercion is set")
+              (is (= :default (:response-type request))
+                  "The response auto-coercion is set")
               (is (not (contains? (:headers request) "Accept"))
                   "The 'Accept' request header is absent"))
             (-> (martian/response-for m :get-anything)

--- a/cljs-http/project.clj
+++ b/cljs-http/project.clj
@@ -24,6 +24,8 @@
                                   [nrepl/nrepl "1.3.1"]
                                   [cider/piggieback "0.6.0"]
 
+                                  [nubank/matcher-combinators "3.9.1"]
+
                                   [org.eclipse.jetty.websocket/websocket-server "9.4.35.v20201120" :upgrade false]
                                   [org.eclipse.jetty.websocket/websocket-servlet "9.4.35.v20201120" :upgrade false]
                                   [pedestal-api "0.3.5"]

--- a/cljs-http/src/martian/cljs_http.cljs
+++ b/cljs-http/src/martian/cljs_http.cljs
@@ -22,9 +22,9 @@
                              (:response (tc/execute (assoc ctx :response response))))))))})
 
 (def response-coerce-opts
-  {:skip-decode #{"application/edn"
-                  "application/json"
-                  "application/transit+json"}
+  {:skip-decoding-for #{"application/edn"
+                        "application/json"
+                        "application/transit+json"}
    :request-key :response-type
    :missing-encoder-as :default
    ;; NB: This must not be `:text`, since this previous global default value

--- a/cljs-http/src/martian/cljs_http.cljs
+++ b/cljs-http/src/martian/cljs_http.cljs
@@ -21,13 +21,18 @@
                        (go (let [response (<! (http/request request))]
                              (:response (tc/execute (assoc ctx :response response))))))))})
 
+(def response-coerce-opts
+  {:skip-decode #{"application/edn"
+                  "application/json"
+                  "application/transit+json"}
+   :request-key :response-type
+   :missing-encoder-as :default
+   :default-encoder-as :default})
+
 (def default-interceptors
   (conj martian/default-interceptors
         i/default-encode-body
-        (i/coerce-response (encoders/default-encoders)
-                           {:request-key :response-type
-                            :missing-encoder-as :default
-                            :default-encoder-as :default})
+        (i/coerce-response (encoders/default-encoders) response-coerce-opts)
         perform-request))
 
 (def default-opts {:interceptors default-interceptors})

--- a/cljs-http/src/martian/cljs_http.cljs
+++ b/cljs-http/src/martian/cljs_http.cljs
@@ -27,6 +27,9 @@
                   "application/transit+json"}
    :request-key :response-type
    :missing-encoder-as :default
+   ;; NB: This must not be `:text`, since this previous global default value
+   ;;     never actually affected `cljs-http` response coercion due to being
+   ;;     passed under the wrong request key, `:as`.
    :default-encoder-as :default})
 
 (def default-interceptors

--- a/cljs-http/test/martian/cljs_http_test.cljs
+++ b/cljs-http/test/martian/cljs_http_test.cljs
@@ -4,6 +4,7 @@
             [martian.cljs-http :as martian-http]
             [martian.core :as martian]
             [martian.interceptors :as i]
+            [matcher-combinators.matchers :as m]
             [matcher-combinators.test])
   (:require-macros [cljs.core.async.macros :refer [go]]
                    [martian.file :refer [load-local-resource]]))
@@ -16,19 +17,18 @@
 (deftest swagger-http-test
   (async done
     (go (let [m (<! (martian-http/bootstrap-swagger swagger-url))]
-
-          (let [response (<! (martian/response-for m :create-pet {:pet {:name "Doggy McDogFace"
-                                                                        :type "Dog"
-                                                                        :age 3}}))]
-            (is (= {:status 201
-                    :body {:id 123}}
-                   (select-keys response [:status :body]))))
-
-          (let [response (<! (martian/response-for m :get-pet {:id 123}))]
-            (is (= {:name "Doggy McDogFace"
-                    :type "Dog"
-                    :age 3}
-                   (:body response)))))
+          (testing "server responses"
+            (is (match?
+                  {:status 201
+                   :body {:id 123}}
+                  (<! (martian/response-for m :create-pet {:pet {:name "Doggy McDogFace"
+                                                                 :type "Dog"
+                                                                 :age 3}}))))
+            (is (match?
+                  {:body {:name "Doggy McDogFace"
+                          :type "Dog"
+                          :age 3}}
+                  (<! (martian/response-for m :get-pet {:id 123}))))))
         (done))))
 
 (deftest openapi-bootstrap-test

--- a/cljs-http/test/martian/cljs_http_test.cljs
+++ b/cljs-http/test/martian/cljs_http_test.cljs
@@ -74,15 +74,13 @@
                  (i/supported-content-types (:interceptors m)))))
         (done))))
 
-;; TODO: The `cljs-http` uses `:response-type` request key for output coercion.
-
 (deftest response-coercion-edn-test
   (async done
     (go (testing "application/edn"
           (let [m (<! (martian-http/bootstrap-openapi openapi-coercions-url))]
             (is (match?
                   {:headers {"Accept" "application/edn"}
-                   #_#_:response-type :default}
+                   :response-type :default}
                   (martian/request-for m :get-edn)))
             (is (match?
                   {:status 200
@@ -97,7 +95,7 @@
           (let [m (<! (martian-http/bootstrap-openapi openapi-coercions-url))]
             (is (match?
                   {:headers {"Accept" "application/json"}
-                   #_#_:response-type :default}
+                   :response-type :default}
                   (martian/request-for m :get-json)))
             (is (match?
                   {:status 200
@@ -112,7 +110,7 @@
           (let [m (<! (martian-http/bootstrap-openapi openapi-coercions-url))]
             (is (match?
                   {:headers {"Accept" "application/transit+json"}
-                   #_#_:response-type :default}
+                   :response-type :default}
                   (martian/request-for m :get-transit+json)))
             (is (match?
                   {:status 200
@@ -127,14 +125,12 @@
           (let [m (<! (martian-http/bootstrap-openapi openapi-coercions-url))]
             (is (match?
                   {:headers {"Accept" "application/x-www-form-urlencoded"}
-                   #_#_:response-type :default}
+                   :response-type :text}
                   (martian/request-for m :get-form-data)))
-            ;; TODO: Fails due to a raw type mismatch (does not apply encoder).
             (is (match?
                   {:status 200
                    :headers {"content-type" "application/x-www-form-urlencoded"}
-                   :body {:message "Here's some text content"}
-                   #_"message=Here%27s+some+text+content"}
+                   :body {:message "Here's some text content"}}
                   (<! (martian/response-for m :get-form-data))))))
         (done))))
 
@@ -147,7 +143,7 @@
                   (martian/handler-for m :get-something)))
             (is (match?
                   {:headers {"Accept" "application/transit+json"}
-                   #_#_:response-type :default}
+                   :response-type :default}
                   (martian/request-for m :get-something)))
             (is (match?
                   {:status 200
@@ -164,8 +160,8 @@
                   {:produces []}
                   (martian/handler-for m :get-anything)))
             (let [request (martian/request-for m :get-anything)]
-              #_(is (= :default (:response-type request))
-                    "The response auto-coercion is set")
+              (is (= :default (:response-type request))
+                  "The response auto-coercion is set")
               (is (not (contains? (:headers request) "Accept"))
                   "The 'Accept' request header is absent"))
             (is (match?

--- a/cljs-http/test/martian/cljs_http_test.cljs
+++ b/cljs-http/test/martian/cljs_http_test.cljs
@@ -63,14 +63,14 @@
 (deftest supported-content-types-test
   (async done
     (go (let [m (<! (martian-http/bootstrap-openapi openapi-url))]
-          (is (= {:encodes #{"application/transit+json"
-                             "application/json"
-                             "application/edn"
-                             "application/x-www-form-urlencoded"}
-                  :decodes #{"application/transit+json"
-                             "application/json"
-                             "application/edn"
-                             "application/x-www-form-urlencoded"}}
+          (is (= {:encodes ["application/transit+json"
+                            "application/edn"
+                            "application/json"
+                            "application/x-www-form-urlencoded"]
+                  :decodes ["application/transit+json"
+                            "application/edn"
+                            "application/json"
+                            "application/x-www-form-urlencoded"]}
                  (i/supported-content-types (:interceptors m)))))
         (done))))
 

--- a/cljs-http/test/martian/cljs_http_test.cljs
+++ b/cljs-http/test/martian/cljs_http_test.cljs
@@ -11,6 +11,7 @@
 (def swagger-url "http://localhost:8888/swagger.json")
 (def openapi-url "http://localhost:8888/openapi.json")
 (def openapi-test-url "http://localhost:8888/openapi-test.json")
+(def openapi-coercions-url "http://localhost:8888/openapi-coercions.json")
 
 (deftest swagger-http-test
   (async done
@@ -76,7 +77,7 @@
 (deftest issue-189-test
   (async done
     (go (testing "operation with '*/*' response content type"
-          (let [m (<! (martian-http/bootstrap-openapi openapi-url {:server-url "http://localhost:8888"}))]
+          (let [m (<! (martian-http/bootstrap-openapi openapi-coercions-url))]
             (is (match?
                   {:method :get
                    :url "http://localhost:8888/issue/189"

--- a/cljs-http/test/martian/cljs_http_test.cljs
+++ b/cljs-http/test/martian/cljs_http_test.cljs
@@ -15,44 +15,44 @@
 
 (deftest swagger-http-test
   (async done
-         (go (let [m (<! (martian-http/bootstrap-swagger swagger-url))]
+    (go (let [m (<! (martian-http/bootstrap-swagger swagger-url))]
 
-               (let [response (<! (martian/response-for m :create-pet {:pet {:name "Doggy McDogFace"
-                                                                             :type "Dog"
-                                                                             :age 3}}))]
-                 (is (= {:status 201
-                         :body {:id 123}}
-                        (select-keys response [:status :body]))))
+          (let [response (<! (martian/response-for m :create-pet {:pet {:name "Doggy McDogFace"
+                                                                        :type "Dog"
+                                                                        :age 3}}))]
+            (is (= {:status 201
+                    :body {:id 123}}
+                   (select-keys response [:status :body]))))
 
-               (let [response (<! (martian/response-for m :get-pet {:id 123}))]
-                 (is (= {:name "Doggy McDogFace"
-                         :type "Dog"
-                         :age 3}
-                        (:body response)))))
-             (done))))
+          (let [response (<! (martian/response-for m :get-pet {:id 123}))]
+            (is (= {:name "Doggy McDogFace"
+                    :type "Dog"
+                    :age 3}
+                   (:body response)))))
+        (done))))
 
 (deftest openapi-bootstrap-test
   (async done
-         (go (let [m (<! (martian-http/bootstrap-openapi openapi-url))]
+    (go (let [m (<! (martian-http/bootstrap-openapi openapi-url))]
 
-               (is (= "https://sandbox.example.com"
-                      (:api-root (<! (martian-http/bootstrap-openapi openapi-test-url))))
-                   "check absolute server url")
+          (is (= "https://sandbox.example.com"
+                 (:api-root (<! (martian-http/bootstrap-openapi openapi-test-url))))
+              "check absolute server url")
 
-               (is (= "https://sandbox.com"
-                      (:api-root (<! (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"}))))
-                   "check absolute server url via opts")
+          (is (= "https://sandbox.com"
+                 (:api-root (<! (martian-http/bootstrap-openapi openapi-test-url {:server-url "https://sandbox.com"}))))
+              "check absolute server url via opts")
 
-               (is (= "http://localhost:8888/v3.1"
-                      (:api-root (<! (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"}))))
-                   "check relative server url via opts")
+          (is (= "http://localhost:8888/v3.1"
+                 (:api-root (<! (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"}))))
+              "check relative server url via opts")
 
-               (is (= "http://localhost:8888/openapi/v3"
-                      (:api-root m)))
+          (is (= "http://localhost:8888/openapi/v3"
+                 (:api-root m)))
 
-               (is (contains? (set (map first (martian/explore m)))
-                              :get-order-by-id)))
-             (done))))
+          (is (contains? (set (map first (martian/explore m)))
+                         :get-order-by-id)))
+        (done))))
 
 (deftest local-file-test
   (let [m (martian/bootstrap-openapi "https://sandbox.example.com" (load-local-resource "public/openapi-test.json") martian-http/default-opts)]
@@ -74,17 +74,103 @@
                  (i/supported-content-types (:interceptors m)))))
         (done))))
 
-(deftest issue-189-test
+;; TODO: The `cljs-http` uses `:response-type` request key for output coercion.
+
+(deftest response-coercion-edn-test
   (async done
-    (go (testing "operation with '*/*' response content type"
+    (go (testing "application/edn"
           (let [m (<! (martian-http/bootstrap-openapi openapi-coercions-url))]
             (is (match?
-                  {:method :get
-                   :url "http://localhost:8888/issue/189"
-                   :response-type :default}
-                  (martian/request-for m :get-something {})))
+                  {:headers {"Accept" "application/edn"}
+                   #_#_:response-type :default}
+                  (martian/request-for m :get-edn)))
             (is (match?
                   {:status 200
-                   :body {:message "Here's some JSON content"}}
-                  (<! (martian/response-for m :get-something {}))))))
+                   :headers {"content-type" "application/edn;charset=UTF-8"}
+                   :body {:message "Here's some text content"}}
+                  (<! (martian/response-for m :get-edn))))))
+        (done))))
+
+(deftest response-coercion-json-test
+  (async done
+    (go (testing "application/json"
+          (let [m (<! (martian-http/bootstrap-openapi openapi-coercions-url))]
+            (is (match?
+                  {:headers {"Accept" "application/json"}
+                   #_#_:response-type :default}
+                  (martian/request-for m :get-json)))
+            (is (match?
+                  {:status 200
+                   :headers {"content-type" "application/json;charset=utf-8"}
+                   :body {:message "Here's some text content"}}
+                  (<! (martian/response-for m :get-json))))))
+        (done))))
+
+(deftest response-coercion-transit+json-test
+  (async done
+    (go (testing "application/transit+json"
+          (let [m (<! (martian-http/bootstrap-openapi openapi-coercions-url))]
+            (is (match?
+                  {:headers {"Accept" "application/transit+json"}
+                   #_#_:response-type :default}
+                  (martian/request-for m :get-transit+json)))
+            (is (match?
+                  {:status 200
+                   :headers {"content-type" "application/transit+json;charset=UTF-8"}
+                   :body {:message "Here's some text content"}}
+                  (<! (martian/response-for m :get-transit+json))))))
+        (done))))
+
+(deftest response-coercion-form-data-test
+  (async done
+    (go (testing "application/x-www-form-urlencoded"
+          (let [m (<! (martian-http/bootstrap-openapi openapi-coercions-url))]
+            (is (match?
+                  {:headers {"Accept" "application/x-www-form-urlencoded"}
+                   #_#_:response-type :default}
+                  (martian/request-for m :get-form-data)))
+            ;; TODO: Fails due to a raw type mismatch (does not apply encoder).
+            (is (match?
+                  {:status 200
+                   :headers {"content-type" "application/x-www-form-urlencoded"}
+                   :body {:message "Here's some text content"}
+                   #_"message=Here%27s+some+text+content"}
+                  (<! (martian/response-for m :get-form-data))))))
+        (done))))
+
+(deftest response-coercion-something-test
+  (async done
+    (go (testing "multiple response content types (default encoders order)"
+          (let [m (<! (martian-http/bootstrap-openapi openapi-coercions-url))]
+            (is (match?
+                  {:produces ["application/transit+json"]}
+                  (martian/handler-for m :get-something)))
+            (is (match?
+                  {:headers {"Accept" "application/transit+json"}
+                   #_#_:response-type :default}
+                  (martian/request-for m :get-something)))
+            (is (match?
+                  {:status 200
+                   :headers {"content-type" "application/transit+json;charset=UTF-8"}
+                   :body {:message "Here's some text content"}}
+                  (<! (martian/response-for m :get-something))))))
+        (done))))
+
+(deftest response-coercion-anything-test
+  (async done
+    (go (testing "any response content type (operation with '*/*' content)"
+          (let [m (<! (martian-http/bootstrap-openapi openapi-coercions-url))]
+            (is (match?
+                  {:produces []}
+                  (martian/handler-for m :get-anything)))
+            (let [request (martian/request-for m :get-anything)]
+              #_(is (= :default (:response-type request))
+                    "The response auto-coercion is set")
+              (is (not (contains? (:headers request) "Accept"))
+                  "The 'Accept' request header is absent"))
+            (is (match?
+                  {:status 200
+                   :headers {"content-type" "application/json;charset=utf-8"}
+                   :body {:message "Here's some text content"}}
+                  (<! (martian/response-for m :get-anything))))))
         (done))))

--- a/core/project.clj
+++ b/core/project.clj
@@ -6,20 +6,23 @@
   :plugins [[lein-parent "0.3.9"]]
   :parent-project {:path "../project.clj"
                    :inherit [:managed-dependencies]}
-  :dependencies [[frankiesardo/tripod "0.2.0"]
+  :dependencies [[camel-snake-kebab "0.4.3"]
+                 [clj-commons/clj-yaml "1.0.29"]
+                 [frankiesardo/tripod "0.2.0"]
+                 [lambdaisland/uri "1.19.155"]
+                 [org.flatland/ordered "1.15.12"]
+
+                 ;; schema and specs
+                 [org.clojure/spec.alpha "0.5.238"]
                  [prismatic/schema "1.4.1"]
                  [metosin/schema-tools "0.13.1"]
                  [metosin/spec-tools "0.10.7"
                   :exclusions [com.fasterxml.jackson.core/jackson-databind]]
-                 [org.clojure/spec.alpha "0.5.238"]
-                 [camel-snake-kebab "0.4.3"]
-                 [cheshire]
-                 [clj-commons/clj-yaml "1.0.29"]
-                 [lambdaisland/uri "1.19.155"]
 
+                 ;; encoding/decoding
+                 [cheshire]
                  [com.cognitect/transit-clj "1.0.333"]
                  [com.cognitect/transit-cljs "0.8.280"]
-                 [org.flatland/ordered "1.15.12"]
                  [ring/ring-codec "1.3.0"]]
   :java-source-paths ["src"]
   :profiles {:provided {:dependencies [[org.clojure/clojure]

--- a/core/project.clj
+++ b/core/project.clj
@@ -34,7 +34,7 @@
                                   [nrepl/nrepl "1.3.1"]
                                   [cider/piggieback "0.6.0"]
 
-                                  [nubank/matcher-combinators "3.8.5"]]
+                                  [nubank/matcher-combinators "3.9.1"]]
                    :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]}}}
   :aliases {"fig"       ["trampoline" "run" "-m" "figwheel.main"]
             "fig:build" ["trampoline" "run" "-m" "figwheel.main" "-b" "dev" "-r"]

--- a/core/src/martian/encoders.cljc
+++ b/core/src/martian/encoders.cljc
@@ -4,36 +4,67 @@
             [cognitect.transit :as transit]
             [flatland.ordered.map :refer [ordered-map]]
             #?(:clj [cheshire.core :as json])
-            #?(:clj [clojure.edn :as edn]
+            #?(:clj  [clojure.edn :as edn]
                :cljs [cljs.reader :as edn])
             #?(:clj [clojure.java.io :as io])
             #?(:clj [martian.multipart :as multipart])
-            #?@(:bb []
+            #?@(:bb  []
                 :clj [[ring.util.codec :as codec]]))
-  #?(:clj (:import [java.io ByteArrayInputStream ByteArrayOutputStream])))
+  #?(:clj (:import [java.io ByteArrayInputStream ByteArrayOutputStream InputStream])))
 
-(defn transit-decode [body type]
-  #?(:clj (transit/read (transit/reader (ByteArrayInputStream. body) type))
-     :cljs (transit/read (transit/reader type {}) body)))
+#?(:clj
+   (defn as-bytes [obj]
+     (cond
+       (bytes? obj) obj
+
+       (string? obj)
+       (.getBytes ^String obj)
+
+       (instance? InputStream obj)
+       (with-open [^InputStream is obj, baos (ByteArrayOutputStream.)]
+         (io/copy is baos)
+         (.toByteArray baos))
+
+       ;; Leave as is and let it fail downstream
+       :else obj)))
+
+#?(:clj
+   (defn as-stream [obj]
+     (if (instance? InputStream obj)
+       obj
+       (ByteArrayInputStream. (as-bytes obj)))))
+
+#?(:clj
+   (defn as-string
+     ([obj]
+      (if (string? obj)
+        obj
+        (as-string obj "UTF-8")))
+     ([obj ^String charset]
+      (if (string? obj)
+        obj
+        (slurp obj :encoding charset)))))
 
 (defn transit-encode [body type]
-  #?(:clj
-     (let [out (ByteArrayOutputStream. 4096)
-           writer (transit/writer out type)]
-       (transit/write writer body)
-       (io/input-stream (.toByteArray out)))
-     :cljs
-     (transit/write (transit/writer type {}) body)))
+  #?(:clj  (let [out (ByteArrayOutputStream. 4096)
+                 writer (transit/writer out type)]
+             (transit/write writer body)
+             ;; TODO: Is it necessary to wrap into stream?
+             (io/input-stream (.toByteArray out)))
+     :cljs (transit/write (transit/writer type {}) body)))
+
+(defn transit-decode [body type]
+  #?(:clj  (transit/read (transit/reader (as-stream body) type))
+     :cljs (transit/read (transit/reader type {}) body)))
 
 (defn json-encode [body]
-  #?(:clj (json/encode body)
+  #?(:clj  (json/encode body)
      :cljs (js/JSON.stringify (clj->js body))))
 
 (defn json-decode [body key-fn]
-  #?(:clj (json/decode body key-fn)
-     :cljs
-     (if-let [v (if-not (string/blank? body) (js/JSON.parse body))]
-       (js->clj v :keywordize-keys key-fn))))
+  #?(:clj  (json/decode body key-fn)
+     :cljs (when-let [v (if-not (string/blank? body) (js/JSON.parse body))]
+             (js->clj v :keywordize-keys key-fn))))
 
 #?(:clj
    (defn multipart-encode
@@ -46,20 +77,22 @@
               {:name (name k) :content (multipart/coerce-content v pass-pred)})
             body))))
 
-#?(:cljs
-   (defn- form-encode [body]
-     (str (js/URLSearchParams. (clj->js body)))))
+(defn form-encode [body]
+  #?(:bb   nil
+     :clj  (codec/form-encode body)
+     :cljs (str (js/URLSearchParams. (clj->js body)))))
 
-#?(:cljs
-   (defn- form-decode [body]
-     (let [params (js/URLSearchParams. body)]
-       (reduce (fn [acc k]
-                 (let [v (.getAll params k)]
-                   (assoc acc (keyword k) (if (= 1 (count v))
-                                            (first v)
-                                            (vec v)))))
-               {}
-               (.keys params)))))
+(defn form-decode [body]
+  #?(:bb   nil
+     :clj  (keywordize-keys (codec/form-decode (as-string body)))
+     :cljs (let [params (js/URLSearchParams. body)]
+             (reduce (fn [acc k]
+                       (let [v (.getAll params k)]
+                         (assoc acc (keyword k) (if (= 1 (count v))
+                                                  (first v)
+                                                  (vec v)))))
+                     {}
+                     (.keys params)))))
 
 (defn default-encoders
   ([] (default-encoders keyword))
@@ -67,28 +100,24 @@
    ;; NB: The order in this map is critically important, since we choose an appropriate
    ;;     encoder for a particular media type sequentially (see `martian.encoding` ns).
    (ordered-map
-     ;; NB: This one must go first and stay separate from the following `:clj/cljs` one
-     ;;     so to be overridden by the `:clj`-specific value on the JVM.
-     #?@(:bb
-         ["application/transit+json" {:encode #(transit-encode % :json)
-                                      :decode #(transit-decode % :json)}])
-     #?@(:clj
+     ;; NB: The `transit+msgpack` is not available when running in BB, but is on the JVM.
+     ;;     j.l.NoClassDefFoundError: Could not initialize class org.msgpack.MessagePack
+     #?@(:bb []
+         :clj
          ["application/transit+msgpack" {:encode #(transit-encode % :msgpack)
                                          :decode #(transit-decode % :msgpack)
-                                         :as :byte-array}
-          "application/transit+json" {:encode #(transit-encode % :json)
-                                      :decode #(transit-decode (.getBytes ^String %) :json)}]
-         :cljs
-         ["application/transit+json" {:encode #(transit-encode % :json)
-                                      :decode #(transit-decode % :json)}])
+                                         :as :byte-array}])
+     "application/transit+json" {:encode #(transit-encode % :json)
+                                 :decode #(transit-decode % :json)}
      "application/edn"  {:encode pr-str
                          :decode edn/read-string}
      "application/json" {:encode json-encode
                          :decode #(json-decode % key-fn)}
      #?@(:bb []
          :clj
-         ["application/x-www-form-urlencoded" {:encode codec/form-encode
-                                               :decode (comp keywordize-keys codec/form-decode)}]
+         ["application/x-www-form-urlencoded" {:encode form-encode
+                                               :decode form-decode}]
          :cljs
          ["application/x-www-form-urlencoded" {:encode form-encode
-                                               :decode form-decode}]))))
+                                               :decode form-decode
+                                               :as :text}]))))

--- a/core/src/martian/encoders.cljc
+++ b/core/src/martian/encoders.cljc
@@ -52,8 +52,7 @@
    #?(:clj  (let [out (ByteArrayOutputStream. 4096)
                   writer (transit/writer out type opts)]
               (transit/write writer body)
-              ;; TODO: Is it necessary to wrap into stream?
-              (io/input-stream (.toByteArray out)))
+              (.toByteArray out))
       :cljs (transit/write (transit/writer type opts) body))))
 
 (defn transit-decode

--- a/core/src/martian/encoders.cljc
+++ b/core/src/martian/encoders.cljc
@@ -98,7 +98,9 @@
   ([] (default-encoders keyword))
   ([key-fn]
    ;; NB: The order in this map is critically important, since we choose an appropriate
-   ;;     encoder for a particular media type sequentially (see `martian.encoding` ns).
+   ;;     encoder for a particular media type sequentially (see `martian.encoding` ns),
+   ;;     as well as preserve the order when collecting supported content types for the
+   ;;     OpenAPI definition parsing.
    (ordered-map
      ;; NB: The `transit+msgpack` is not available when running in BB, but is on the JVM.
      ;;     j.l.NoClassDefFoundError: Could not initialize class org.msgpack.MessagePack

--- a/core/src/martian/encoding.cljc
+++ b/core/src/martian/encoding.cljc
@@ -1,6 +1,5 @@
 (ns martian.encoding
-  (:require [clojure.string :as str])
-  #?(:clj (:import (java.io InputStream))))
+  (:require [clojure.string :as str]))
 
 (defn choose-media-type [encoders options]
   (some (set options) (keys encoders)))
@@ -29,7 +28,3 @@
       (if-let [encoder-as (:as encoder)]
         [:encoder encoder-as]
         [:default default-encoder-as]))))
-
-(def raw-type?
-  #?(:clj  #(or (string? %) (bytes? %) (instance? InputStream %))
-     :cljs string?))

--- a/core/src/martian/encoding.cljc
+++ b/core/src/martian/encoding.cljc
@@ -1,5 +1,5 @@
 (ns martian.encoding
-  (:require [clojure.string :as string]))
+  (:require [clojure.string :as str]))
 
 (defn choose-media-type [encoders options]
   (some (set options) (keys encoders)))
@@ -8,17 +8,14 @@
   {:encode identity
    :decode identity})
 
+(defn get-type-subtype [^String media-type]
+  (str/trim
+    (if-some [params-sep-idx (str/index-of media-type \;)]
+      (subs media-type 0 params-sep-idx)
+      media-type)))
+
 (defn find-encoder [encoders media-type]
-  (if (string/blank? media-type)
-    auto-encoder
-    (loop [encoders encoders]
-      (let [[encoder-media-type encoder] (first encoders)]
-        (cond
-          (not encoder)
-          auto-encoder
-
-          (string/includes? media-type encoder-media-type)
-          encoder
-
-          :else
-          (recur (rest encoders)))))))
+  (if (and (string? media-type) (not (str/blank? media-type)))
+    (let [type-subtype (get-type-subtype media-type)]
+      (get encoders type-subtype auto-encoder))
+    auto-encoder))

--- a/core/src/martian/encoding.cljc
+++ b/core/src/martian/encoding.cljc
@@ -1,5 +1,6 @@
 (ns martian.encoding
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str])
+  #?(:clj (:import (java.io InputStream))))
 
 (defn choose-media-type [encoders options]
   (some (set options) (keys encoders)))
@@ -19,3 +20,16 @@
   (or (when-some [type-subtype (get-type-subtype media-type)]
         (get encoders type-subtype auto-encoder))
       auto-encoder))
+
+(defn coerce-as
+  [encoders media-type {:keys [missing-encoder-as default-encoder-as]}]
+  (let [encoder (find-encoder encoders media-type)]
+    (if (= auto-encoder encoder)
+      [:missing missing-encoder-as]
+      (if-let [encoder-as (:as encoder)]
+        [:encoder encoder-as]
+        [:default default-encoder-as]))))
+
+(def raw-type?
+  #?(:clj  #(or (string? %) (bytes? %) (instance? InputStream %))
+     :cljs string?))

--- a/core/src/martian/encoding.cljc
+++ b/core/src/martian/encoding.cljc
@@ -8,14 +8,14 @@
   {:encode identity
    :decode identity})
 
-(defn get-type-subtype [^String media-type]
-  (str/trim
-    (if-some [params-sep-idx (str/index-of media-type \;)]
-      (subs media-type 0 params-sep-idx)
-      media-type)))
+(defn get-type-subtype [media-type]
+  (when (and (string? media-type) (not (str/blank? media-type)))
+    (str/trim
+      (if-some [params-sep-idx (str/index-of media-type \;)]
+        (subs media-type 0 params-sep-idx)
+        media-type))))
 
 (defn find-encoder [encoders media-type]
-  (if (and (string? media-type) (not (str/blank? media-type)))
-    (let [type-subtype (get-type-subtype media-type)]
-      (get encoders type-subtype auto-encoder))
-    auto-encoder))
+  (or (when-some [type-subtype (get-type-subtype media-type)]
+        (get encoders type-subtype auto-encoder))
+      auto-encoder))

--- a/core/src/martian/encoding.cljc
+++ b/core/src/martian/encoding.cljc
@@ -13,13 +13,13 @@
   (if (string/blank? content-type)
     auto-encoder
     (loop [encoders encoders]
-      (let [[ct encoder] (first encoders)]
+      (let [[encoder-content-type encoder] (first encoders)]
         (cond
-          (not content-type) auto-encoder
+          (not encoder)
+          auto-encoder
 
-          (not encoder) auto-encoder
-
-          (string/includes? content-type ct) encoder
+          (string/includes? content-type encoder-content-type)
+          encoder
 
           :else
           (recur (rest encoders)))))))

--- a/core/src/martian/encoding.cljc
+++ b/core/src/martian/encoding.cljc
@@ -1,12 +1,10 @@
 (ns martian.encoding
   (:require [clojure.string :as str]))
 
+;; Media Types
+
 (defn choose-media-type [encoders options]
   (some (set options) (keys encoders)))
-
-(def auto-encoder
-  {:encode identity
-   :decode identity})
 
 (defn get-type-subtype [media-type]
   (when (and (string? media-type) (not (str/blank? media-type)))
@@ -15,16 +13,80 @@
         (subs media-type 0 params-sep-idx)
         media-type))))
 
+;; Encoder Selection
+
+(def auto-encoder
+  {:encode identity
+   :decode identity})
+
 (defn find-encoder [encoders media-type]
   (or (when-some [type-subtype (get-type-subtype media-type)]
         (get encoders type-subtype auto-encoder))
       auto-encoder))
 
-(defn coerce-as
+;; Response Coercion
+
+(defn set-default-coerce-opts
+  "Returns an HTTP client-specific response coercion options, applying default
+   values, if necessary:
+   - `:skip-decoding-for`    — a set of media types for which the decoding can
+                               be skipped in favor of the client built-in one
+   - `:auto-coercion-pred`   — a pred of `coerce-as-value` that checks whether
+                               client response auto-coercion has been applied
+   - `:request-key`          — usually `:as`, though some clients expect other
+                               keys, e.g. `:response-type` for the `cljs-http`
+   - `:missing-encoder-as`   — for the case where the media type is missing or
+                               when there is no encoder for the specified type
+   - `:default-encoder-as`   — for in case the found encoder for the specified
+                               media type omits its own `:as` value"
+  [{:keys [skip-decoding-for auto-coercion-pred
+           request-key missing-encoder-as default-encoder-as]
+    :or {missing-encoder-as :auto
+         ;; NB: Better be `:auto` to leverage the built-in client coercions
+         ;;     which are usually based on the Content-Type response header.
+         ;;     Leaving `:string` (the same as `:text`) for backward compat.
+         default-encoder-as :string}}]
+  {:skip-decoding-for (or skip-decoding-for #{})
+   :auto-coercion-pred (or auto-coercion-pred (constantly false))
+   :request-key (or request-key :as)
+   ;; NB: Passing `nil` to any of these must be a valid option.
+   :missing-encoder-as missing-encoder-as
+   :default-encoder-as default-encoder-as})
+
+(defn get-coerce-as
   [encoders media-type {:keys [missing-encoder-as default-encoder-as]}]
   (let [encoder (find-encoder encoders media-type)]
     (if (= auto-encoder encoder)
-      [:missing missing-encoder-as]
+      {:type :missing
+       :value missing-encoder-as}
       (if-let [encoder-as (:as encoder)]
-        [:encoder encoder-as]
-        [:default default-encoder-as]))))
+        {:type :encoder
+         :value encoder-as}
+        {:type :default
+         :value default-encoder-as}))))
+
+(defn skip-decoding?
+  "Checks whether a response decoding (by Martian) should be skipped.
+
+   Skip only when the client did coerce a response to the final type,
+   which may not be the case if the 'Accept' encoder had some custom
+   (non-default) `:as` value, meaning it still expects to decode the
+   response from this (intermediary) type to the final one."
+  [{:keys [type] :as _coerce-as}
+   content-type
+   {:keys [skip-decoding-for] :as _coerce-opts}]
+  (let [type-subtype (get-type-subtype content-type)]
+    (and (contains? skip-decoding-for type-subtype)
+         (not= :encoder type))))
+
+(defn auto-coercion-by-client?
+  "Checks if a response should have already gone through the client's
+   auto-coercion (to avoid double coercion of the same sort).
+
+   A workaround needed specifically for `clj-http` and `hato` clients
+   with response auto-coercion being turned on e.g. due to a presence
+   of the '*/*' response content in the OpenAPI/Swagger definition."
+  [{:keys [type value] :as _coerce-as}
+   {:keys [auto-coercion-pred] :as _coerce-opts}]
+  (and (= :missing type)
+       (auto-coercion-pred value)))

--- a/core/src/martian/encoding.cljc
+++ b/core/src/martian/encoding.cljc
@@ -6,8 +6,7 @@
 
 (def auto-encoder
   {:encode identity
-   :decode identity
-   :as :auto})
+   :decode identity})
 
 (defn find-encoder [encoders content-type]
   (if (string/blank? content-type)

--- a/core/src/martian/encoding.cljc
+++ b/core/src/martian/encoding.cljc
@@ -1,23 +1,23 @@
 (ns martian.encoding
   (:require [clojure.string :as string]))
 
-(defn choose-content-type [encoders options]
+(defn choose-media-type [encoders options]
   (some (set options) (keys encoders)))
 
 (def auto-encoder
   {:encode identity
    :decode identity})
 
-(defn find-encoder [encoders content-type]
-  (if (string/blank? content-type)
+(defn find-encoder [encoders media-type]
+  (if (string/blank? media-type)
     auto-encoder
     (loop [encoders encoders]
-      (let [[encoder-content-type encoder] (first encoders)]
+      (let [[encoder-media-type encoder] (first encoders)]
         (cond
           (not encoder)
           auto-encoder
 
-          (string/includes? content-type encoder-content-type)
+          (string/includes? media-type encoder-media-type)
           encoder
 
           :else

--- a/core/src/martian/interceptors.cljc
+++ b/core/src/martian/interceptors.cljc
@@ -155,7 +155,6 @@
     :enter (fn [{:keys [request handler] :as ctx}]
              (let [resp-media-type (when (not (get-in request [:headers "Accept"]))
                                      (encoding/choose-media-type encoders (:produces handler)))
-                   ;; TODO: Must not pick up an unsupported value `:auto` for the `bb-http-client`.
                    resp-coerce-as (coerce-as (encoding/find-encoder encoders resp-media-type) coerce-as-opts)
                    req-with-out-coercion (cond-> request
                                            resp-coerce-as (conj resp-coerce-as)

--- a/core/src/martian/interceptors.cljc
+++ b/core/src/martian/interceptors.cljc
@@ -132,7 +132,7 @@
 (defn set-default-coerce-opts
   "Returns an HTTP client-specific response coercion options, applying default
    values, if necessary:
-   - `:skip-decode`          — a set of media types for which the decoding can
+   - `:skip-decoding-for`    — a set of media types for which the decoding can
                                be skipped in favor of the client built-in one
    - `:request-key`          — usually `:as`, though some clients expect other
                                keys, e.g. `:response-type` for the `cljs-http`
@@ -140,13 +140,13 @@
                                when there is no encoder for the specified type
    - `:default-encoder-as`   — for in case the found encoder for the specified
                                media type omits its own `:as` value"
-  [{:keys [skip-decode request-key missing-encoder-as default-encoder-as]
+  [{:keys [skip-decoding-for request-key missing-encoder-as default-encoder-as]
     :or {missing-encoder-as :auto
          ;; NB: Better be `:auto` to leverage the built-in client coercions
          ;;     which are usually based on the Content-Type response header.
          ;;     Leaving `:string` (the same as `:text`) for backward compat.
          default-encoder-as :string}}]
-  {:skip-decode (or skip-decode #{})
+  {:skip-decoding-for (or skip-decoding-for #{})
    :request-key (or request-key :as)
    ;; NB: Passing `nil` to any of these must be a valid option.
    :missing-encoder-as missing-encoder-as
@@ -195,7 +195,7 @@
                            ;;     which may not be the case if the "Accept" encoder had some custom
                            ;;     (non-default) `:as` value, meaning it still expects to decode the
                            ;;     response from this (intermediary) type to the final one.
-                           (and (contains? (:skip-decode coerce-opts) type-subtype)
+                           (and (contains? (:skip-decoding-for coerce-opts) type-subtype)
                                 (has-coerce-as-value? :default request coerce-opts))
                            ;; NB: Avoid double coercion of same sort by the client and then Martian.
                            ;;     A workaround needed specifically for `clj-http` and `hato` clients

--- a/core/src/martian/interceptors.cljc
+++ b/core/src/martian/interceptors.cljc
@@ -147,10 +147,12 @@
     {request-key val}))
 
 (defn delegate-response-decoding?
-  [coerce-as {:keys [request-key missing-encoder-as]
+  [coerce-as {:keys [request-key missing-encoder-as delegate-on-missing?]
               :or {request-key :as
-                   missing-encoder-as :auto}}]
-  (= missing-encoder-as (get coerce-as request-key ::not-found)))
+                   missing-encoder-as :auto
+                   delegate-on-missing? true}}]
+  (and delegate-on-missing?
+       (= missing-encoder-as (get coerce-as request-key ::not-found))))
 
 (defn coerce-response
   ([encoders]

--- a/core/src/martian/interceptors.cljc
+++ b/core/src/martian/interceptors.cljc
@@ -129,18 +129,22 @@
 (def default-encode-body default-encode-request)
 
 (defn coerce-as
-  "Returns an HTTP-client-specific `:as` value for response coercion, using
+  "Returns an HTTP-client-specific request entry for response coercion, using
    the provided default values:
+   - `:request-key`        — usually `:as`, though some clients expect other
+                             keys, e.g. `:response-type` for the `cljs-http`
    - `:missing-encoder-as` — for the case where the media type is missing or
                              when there is no encoder for the specified type
    - `:default-encoder-as` — for in case the found encoder for the specified
                              media type omits its own `:as` value"
-  [encoder {:keys [missing-encoder-as default-encoder-as]
-            :or {missing-encoder-as :auto
+  [encoder {:keys [request-key missing-encoder-as default-encoder-as]
+            :or {request-key :as
+                 missing-encoder-as :auto
                  default-encoder-as :text}}]
-  (if (= encoding/auto-encoder encoder)
-    missing-encoder-as
-    (or (:as encoder) default-encoder-as)))
+  (when-let [val (if (= encoding/auto-encoder encoder)
+                   missing-encoder-as
+                   (or (:as encoder) default-encoder-as))]
+    {request-key val}))
 
 (defn coerce-response
   ([encoders]
@@ -154,7 +158,7 @@
                    ;; TODO: Must not pick up an unsupported value `:auto` for the `bb-http-client`.
                    resp-coerce-as (coerce-as (encoding/find-encoder encoders resp-media-type) coerce-as-opts)
                    req-with-out-coercion (cond-> request
-                                           resp-coerce-as (assoc :as resp-coerce-as)
+                                           resp-coerce-as (conj resp-coerce-as)
                                            resp-media-type (assoc-in [:headers "Accept"] resp-media-type))]
                (assoc ctx :request req-with-out-coercion)))
     :leave (fn [{:keys [response] :as ctx}]

--- a/core/src/martian/interceptors.cljc
+++ b/core/src/martian/interceptors.cljc
@@ -141,7 +141,10 @@
                                media type omits its own `:as` value"
   [{:keys [skip-decode request-key missing-encoder-as default-encoder-as]
     :or {missing-encoder-as :auto
-         default-encoder-as :text}}]
+         ;; NB: Better be `:auto` to leverage the built-in client coercions
+         ;;     which are usually based on the Content-Type response header.
+         ;;     Leaving `:string` (the same as `:text`) for backward compat.
+         default-encoder-as :string}}]
   {:skip-decode (or skip-decode #{})
    :request-key (or request-key :as)
    ;; NB: Passing `nil` to any of these must be a valid option.

--- a/core/src/martian/interceptors.cljc
+++ b/core/src/martian/interceptors.cljc
@@ -229,13 +229,16 @@
              ctx)}))
 
 (defn supported-content-types
-  "Return the full set of supported content-types as declared by any encoding/decoding interceptors"
+  "Return the full set of supported content-types as declared by any encoding/decoding interceptors,
+   preserving their original declaration order."
   [interceptors]
-  (reduce (fn [acc interceptor]
-            (merge-with into acc (select-keys interceptor [:encodes :decodes])))
-          {:encodes #{}
-           :decodes #{}}
-          interceptors))
+  (-> (reduce (fn [acc interceptor]
+                (merge-with into acc (select-keys interceptor [:encodes :decodes])))
+              {:encodes []
+               :decodes []}
+              interceptors)
+      (update :encodes distinct)
+      (update :decodes distinct)))
 
 ;; borrowed from https://github.com/walmartlabs/lacinia-pedestal/blob/master/src/com/walmartlabs/lacinia/pedestal.clj#L40
 (defn inject

--- a/core/src/martian/openapi.cljc
+++ b/core/src/martian/openapi.cljc
@@ -136,6 +136,7 @@
             (keyword param-name)
             %) parts)))
 
+;; TODO: Substitute with `update-vals` (built-in, cross-platform).
 (defn update-vals-future
   "An implementation of `update-vals` that is in Clojure 1.11.0+."
   [m f]

--- a/core/src/martian/utils.cljc
+++ b/core/src/martian/utils.cljc
@@ -4,3 +4,13 @@
 (defn string->int [s]
   #?(:clj (Long/parseLong s)
      :cljs (js/parseInt s)))
+
+(defn update*
+  ([m k f]
+   (update* m k f nil))
+  ([m k f & args]
+   (if (contains? m k)
+     (if (seq args)
+       (apply update m k f args)
+       (update m k f))
+     m)))

--- a/core/src/martian/utils.cljc
+++ b/core/src/martian/utils.cljc
@@ -1,8 +1,8 @@
 (ns martian.utils)
 
-
+;; TODO: Substitute with `parse-long` (built-in, cross-platform).
 (defn string->int [s]
-  #?(:clj (Long/parseLong s)
+  #?(:clj  (Long/parseLong s)
      :cljs (js/parseInt s)))
 
 (defn update*

--- a/core/test/martian/encoding_test.cljc
+++ b/core/test/martian/encoding_test.cljc
@@ -7,6 +7,38 @@
 
 (def encoders (encoders/default-encoders))
 
+(deftest get-type-subtype-test
+  (testing "normalized (no whitespaces)"
+    (is (= "*/*"
+           (encoding/get-type-subtype "*/*")))
+    (is (= "text/*"
+           (encoding/get-type-subtype "text/*")))
+    (is (= "text/plain"
+           (encoding/get-type-subtype "text/plain")))
+    (is (= "text/plain"
+           (encoding/get-type-subtype "text/plain; charset=iso-8859-1")))
+    (is (= "application/json"
+           (encoding/get-type-subtype "application/json")))
+    (is (= "application/json"
+           (encoding/get-type-subtype "application/json; charset=utf-8")))
+    (is (= "application/edn"
+           (encoding/get-type-subtype "application/edn")))
+    (is (= "image/svg+xml"
+           (encoding/get-type-subtype "image/svg+xml")))
+    (is (= "audio/*"
+           (encoding/get-type-subtype "audio/*; q=0.8")))
+    (is (= "multipart/form-data"
+           (encoding/get-type-subtype "multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW"))))
+  (testing "with optional whitespace (OWS)"
+    (is (= "text/plain"
+           (encoding/get-type-subtype "text/plain  ; charset=iso-8859-1")))
+    (is (= "text/plain"
+           (encoding/get-type-subtype "text/plain\t; charset=iso-8859-1")))
+    (is (= "application/json"
+           (encoding/get-type-subtype "application/json ; charset=utf-8")))
+    (is (= "application/json"
+           (encoding/get-type-subtype "application/json\t; charset=utf-8")))))
+
 (deftest find-encoder-test
   (testing "no encoders"
     (is (= encoding/auto-encoder

--- a/core/test/martian/encoding_test.cljc
+++ b/core/test/martian/encoding_test.cljc
@@ -1,0 +1,32 @@
+(ns martian.encoding-test
+  (:require [martian.encoders :as encoders]
+            [martian.encoding :as encoding]
+            [matcher-combinators.test]
+            #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest testing is]])))
+
+(def encoders (encoders/default-encoders))
+
+(deftest find-encoder-test
+  (testing "no encoders"
+    (is (= encoding/auto-encoder
+           (encoding/find-encoder nil nil)))
+    (is (= encoding/auto-encoder
+           (encoding/find-encoder nil "*/*")))
+    (is (= encoding/auto-encoder
+           (encoding/find-encoder nil "text/plain")))
+    (is (= encoding/auto-encoder
+           (encoding/find-encoder nil "application/edn")))
+    (is (= encoding/auto-encoder
+           (encoding/find-encoder nil "application/json"))))
+  (testing "default encoders"
+    (is (= encoding/auto-encoder
+           (encoding/find-encoder encoders nil)))
+    (is (= encoding/auto-encoder
+           (encoding/find-encoder encoders "*/*")))
+    (is (= encoding/auto-encoder
+           (encoding/find-encoder encoders "text/plain")))
+    (is (= (get encoders "application/edn")
+           (encoding/find-encoder encoders "application/edn")))
+    (is (= (get encoders "application/json")
+           (encoding/find-encoder encoders "application/json")))))

--- a/core/test/martian/interceptors_test.cljc
+++ b/core/test/martian/interceptors_test.cljc
@@ -203,12 +203,33 @@
                                                                          :decode #(encoders/json-decode % keyword)
                                                                          :as :magic}))]
 
-      (is (= {:encodes #?(:bb #{"application/json" "application/transit+msgpack" "application/transit+json" "application/edn"}
-                          :clj #{"application/json" "application/transit+msgpack" "application/transit+json" "application/edn" "application/x-www-form-urlencoded"}
-                          :cljs #{"application/json" "application/transit+json" "application/edn" "application/x-www-form-urlencoded"})
-              :decodes #?(:bb #{"application/json" "text/magical+json" "application/transit+msgpack" "application/transit+json" "application/edn"}
-                          :clj #{"application/json" "text/magical+json" "application/transit+msgpack" "application/transit+json" "application/edn" "application/x-www-form-urlencoded"}
-                          :cljs #{"application/json" "text/magical+json" "application/transit+json" "application/edn" "application/x-www-form-urlencoded"})}
+      (is (= {:encodes #?(:bb   ["application/transit+json"
+                                 "application/edn"
+                                 "application/json"]
+                          :clj  ["application/transit+msgpack"
+                                 "application/transit+json"
+                                 "application/edn"
+                                 "application/json"
+                                 "application/x-www-form-urlencoded"]
+                          :cljs ["application/transit+json"
+                                 "application/edn"
+                                 "application/json"
+                                 "application/x-www-form-urlencoded"])
+              :decodes #?(:bb   ["application/transit+json"
+                                 "application/edn"
+                                 "application/json"
+                                 "text/magical+json"]
+                          :clj  ["application/transit+msgpack"
+                                 "application/transit+json"
+                                 "application/edn"
+                                 "application/json"
+                                 "application/x-www-form-urlencoded"
+                                 "text/magical+json"]
+                          :cljs ["application/transit+json"
+                                 "application/edn"
+                                 "application/json"
+                                 "application/x-www-form-urlencoded"
+                                 "text/magical+json"])}
              (i/supported-content-types [encode-request coerce-response]))))))
 
 (deftest validate-response-test

--- a/hato/src/martian/hato.clj
+++ b/hato/src/martian/hato.clj
@@ -51,11 +51,12 @@
 ;;     we could and, actually, should skip decoding some media types.
 ;;     https://github.com/gnarroway/hato#request-options
 (def response-coerce-opts
-  {:skip-decoding-for #{"application/edn"
-                        "application/json"
-                        "application/transit+json"
-                        "application/transit+msgpack"}
-   :default-encoder-as :auto})
+  #_{:skip-decoding-for #{"application/edn"
+                          "application/json"
+                          "application/transit+json"
+                          "application/transit+msgpack"}
+     :default-encoder-as :auto}
+  {:default-encoder-as :string})
 
 (def hato-interceptors
   (conj martian/default-interceptors

--- a/hato/src/martian/hato.clj
+++ b/hato/src/martian/hato.clj
@@ -52,13 +52,14 @@
 ;;     decoding for those media types.
 ;;     https://github.com/gnarroway/hato#request-options
 (defn response-coerce-opts [use-client-output-coercion?]
-  (if use-client-output-coercion?
-    {:skip-decoding-for #{"application/edn"
-                          "application/json"
-                          "application/transit+json"
-                          "application/transit+msgpack"}
-     :default-encoder-as :auto}
-    {:default-encoder-as :string}))
+  (conj {:auto-coercion-pred #{:auto}}
+        (if use-client-output-coercion?
+          {:skip-decoding-for #{"application/edn"
+                                "application/json"
+                                "application/transit+json"
+                                "application/transit+msgpack"}
+           :default-encoder-as :auto}
+          {:default-encoder-as :string})))
 
 (defn build-default-interceptors [use-client-output-coercion?]
   (conj martian/default-interceptors

--- a/hato/src/martian/hato.clj
+++ b/hato/src/martian/hato.clj
@@ -52,12 +52,12 @@
 ;;     https://github.com/gnarroway/hato#request-options
 (def response-coerce-opts
   ;; TODO: It better go through the built-in client coercions, but this change is breaking!
-  #_{:skip-decode #{"application/edn"
-                    "application/json"
-                    "application/transit+json"
-                    "application/transit+msgpack"}
-     :default-encoder-as :auto}
-  {:default-encoder-as nil})
+  {:skip-decode #{"application/edn"
+                  "application/json"
+                  "application/transit+json"
+                  "application/transit+msgpack"}
+   :default-encoder-as :auto}
+  #_{:default-encoder-as nil})
 
 (def hato-interceptors
   (conj martian/default-interceptors

--- a/hato/src/martian/hato.clj
+++ b/hato/src/martian/hato.clj
@@ -51,10 +51,10 @@
 ;;     we could and, actually, should skip decoding some media types.
 ;;     https://github.com/gnarroway/hato#request-options
 (def response-coerce-opts
-  {:skip-decode #{"application/edn"
-                  "application/json"
-                  "application/transit+json"
-                  "application/transit+msgpack"}
+  {:skip-decoding-for #{"application/edn"
+                        "application/json"
+                        "application/transit+json"
+                        "application/transit+msgpack"}
    :default-encoder-as :auto})
 
 (def hato-interceptors

--- a/hato/src/martian/hato.clj
+++ b/hato/src/martian/hato.clj
@@ -51,13 +51,11 @@
 ;;     we could and, actually, should skip decoding some media types.
 ;;     https://github.com/gnarroway/hato#request-options
 (def response-coerce-opts
-  ;; TODO: It better go through the built-in client coercions, but this change is breaking!
   {:skip-decode #{"application/edn"
                   "application/json"
                   "application/transit+json"
                   "application/transit+msgpack"}
-   :default-encoder-as :auto}
-  #_{:default-encoder-as nil})
+   :default-encoder-as :auto})
 
 (def hato-interceptors
   (conj martian/default-interceptors

--- a/hato/src/martian/hato.clj
+++ b/hato/src/martian/hato.clj
@@ -46,16 +46,18 @@
   (assoc (encoders/default-encoders)
     "multipart/form-data" {:encode encoders/multipart-encode}))
 
-;; TODO: This actually doesn't work for some reason... Double-check and fix!
-;; NB: In accordance with the `hato`'s Optional Dependencies which just happen
+;; NB: In accordance with the `hato`'s Optional Dependencies, which all happen
 ;;     to be on the classpath already as the Martian core module dependencies,
-;;     we should skip decoding some media types.
+;;     we could and, actually, should skip decoding some media types.
 ;;     https://github.com/gnarroway/hato#request-options
 (def response-coerce-opts
-  {:skip-decode #{"application/edn"
-                  "application/json"
-                  "application/transit+json"
-                  "application/transit+msgpack"}})
+  ;; TODO: It better go through the built-in client coercions, but this change is breaking!
+  #_{:skip-decode #{"application/edn"
+                    "application/json"
+                    "application/transit+json"
+                    "application/transit+msgpack"}
+     :default-encoder-as :auto}
+  {:default-encoder-as nil})
 
 (def hato-interceptors
   (conj martian/default-interceptors

--- a/hato/src/martian/hato.clj
+++ b/hato/src/martian/hato.clj
@@ -73,7 +73,7 @@
                        (if async? perform-request-async perform-request))})
 
 (def hato-interceptors
-  (build-default-interceptors true))
+  (build-default-interceptors false))
 
 (def default-interceptors
   (conj hato-interceptors perform-request))

--- a/hato/src/martian/hato.clj
+++ b/hato/src/martian/hato.clj
@@ -46,10 +46,21 @@
   (assoc (encoders/default-encoders)
     "multipart/form-data" {:encode encoders/multipart-encode}))
 
+;; TODO: This actually doesn't work for some reason... Double-check and fix!
+;; NB: In accordance with the `hato`'s Optional Dependencies which just happen
+;;     to be on the classpath already as the Martian core module dependencies,
+;;     we should skip decoding some media types.
+;;     https://github.com/gnarroway/hato#request-options
+(def response-coerce-opts
+  {:skip-decode #{"application/edn"
+                  "application/json"
+                  "application/transit+json"
+                  "application/transit+msgpack"}})
+
 (def hato-interceptors
   (conj martian/default-interceptors
         (interceptors/encode-request request-encoders)
-        interceptors/default-coerce-response
+        (interceptors/coerce-response (encoders/default-encoders) response-coerce-opts)
         keywordize-headers
         default-to-http-1))
 

--- a/hato/test/martian/hato_test.clj
+++ b/hato/test/martian/hato_test.clj
@@ -321,15 +321,15 @@
 
     (testing "multiple response content types (default encoders order)"
       (is (match?
-            {:produces ["application/json"]}
+            {:produces ["application/transit+json"]}
             (martian/handler-for m :get-something)))
       (is (match?
-            {:headers {"Accept" "application/json"}
+            {:headers {"Accept" "application/transit+json"}
              :as :auto}
             (martian/request-for m :get-something)))
       (is (match?
             {:status 200
-             :headers {:content-type "application/json;charset=utf-8"}
+             :headers {:content-type "application/transit+json;charset=UTF-8"}
              :body {:message "Here's some text content"}}
             (martian/response-for m :get-something))))
 

--- a/hato/test/martian/hato_test.clj
+++ b/hato/test/martian/hato_test.clj
@@ -310,6 +310,7 @@
              :headers {:content-type "application/transit+msgpack;charset=UTF-8"}
              :body {:message "Here's some text content"}}
             (martian/response-for m :get-transit+msgpack))))
+    ;; TODO: Fails due to a raw type mismatch (expects a string, gets a stream).
     (testing "application/x-www-form-urlencoded"
       (is (match?
             {:headers {"Accept" "application/x-www-form-urlencoded"}

--- a/hato/test/martian/hato_test.clj
+++ b/hato/test/martian/hato_test.clj
@@ -261,3 +261,16 @@
                  :body {:content-type multipart+boundary?
                         :content-map {:custom (str int-num)}}}
                 (martian/response-for m :upload-data {:custom int-num}))))))))
+
+(deftest issue-189-test
+  (testing "operation with '*/*' response content type"
+    (let [m (martian-http/bootstrap-openapi openapi-url {:server-url "http://localhost:8888"})]
+      (is (match?
+            {:method :get
+             :url "http://localhost:8888/issue/189"
+             :as :auto}
+            (martian/request-for m :get-something {})))
+      (is (match?
+            {:status 200
+             :body {:message "Here's some JSON content"}}
+            (martian/response-for m :get-something {}))))))

--- a/hato/test/martian/hato_test.clj
+++ b/hato/test/martian/hato_test.clj
@@ -12,6 +12,7 @@
                                          openapi-test-yaml-url
                                          openapi-multipart-url
                                          test-multipart-file-url
+                                         openapi-coercions-url
                                          with-server]]
             [martian.test-utils :refer [binary-content
                                         create-temp-file
@@ -264,7 +265,7 @@
 
 (deftest issue-189-test
   (testing "operation with '*/*' response content type"
-    (let [m (martian-http/bootstrap-openapi openapi-url {:server-url "http://localhost:8888"})]
+    (let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
       (is (match?
             {:method :get
              :url "http://localhost:8888/issue/189"

--- a/hato/test/martian/hato_test.clj
+++ b/hato/test/martian/hato_test.clj
@@ -263,13 +263,14 @@
                 (martian/response-for m :upload-data {:custom int-num}))))))))
 
 (deftest response-coercion-test
-  (let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
+  (let [m (martian-http/bootstrap-openapi openapi-coercions-url)
+        default-coerce-as (:default-encoder-as martian-http/response-coerce-opts)]
     (is (= "http://localhost:8888" (:api-root m)))
 
     (testing "application/edn"
       (is (match?
             {:headers {"Accept" "application/edn"}
-             :as :auto}
+             :as default-coerce-as}
             (martian/request-for m :get-edn)))
       (is (match?
             {:status 200
@@ -279,7 +280,7 @@
     (testing "application/json"
       (is (match?
             {:headers {"Accept" "application/json"}
-             :as :auto}
+             :as default-coerce-as}
             (martian/request-for m :get-json)))
       (is (match?
             {:status 200
@@ -289,7 +290,7 @@
     (testing "application/transit+json"
       (is (match?
             {:headers {"Accept" "application/transit+json"}
-             :as :auto}
+             :as default-coerce-as}
             (martian/request-for m :get-transit+json)))
       (is (match?
             {:status 200
@@ -310,7 +311,7 @@
     (testing "application/x-www-form-urlencoded"
       (is (match?
             {:headers {"Accept" "application/x-www-form-urlencoded"}
-             :as :auto}
+             :as default-coerce-as}
             (martian/request-for m :get-form-data)))
       (is (match?
             {:status 200
@@ -324,7 +325,7 @@
             (martian/handler-for m :get-something)))
       (is (match?
             {:headers {"Accept" "application/transit+json"}
-             :as :auto}
+             :as default-coerce-as}
             (martian/request-for m :get-something)))
       (is (match?
             {:status 200

--- a/hato/test/martian/hato_test.clj
+++ b/hato/test/martian/hato_test.clj
@@ -308,7 +308,6 @@
              :headers {:content-type "application/transit+msgpack;charset=UTF-8"}
              :body {:message "Here's some text content"}}
             (martian/response-for m :get-transit+msgpack))))
-    ;; TODO: Fails due to a raw type mismatch (expects a string, gets a stream).
     (testing "application/x-www-form-urlencoded"
       (is (match?
             {:headers {"Accept" "application/x-www-form-urlencoded"}

--- a/hato/test/martian/hato_test.clj
+++ b/hato/test/martian/hato_test.clj
@@ -57,7 +57,7 @@
              (:body response))))))
 
 (deftest async-test
-  (let [m (martian-http/bootstrap-swagger swagger-url {:interceptors martian-http/default-interceptors-async})]
+  (let [m (martian-http/bootstrap-swagger swagger-url {:async? true})]
 
     (testing "default encoders"
       (is (= {:version :http-1.1
@@ -262,9 +262,12 @@
                         :content-map {:custom (str int-num)}}}
                 (martian/response-for m :upload-data {:custom int-num}))))))))
 
-(deftest response-coercion-test
-  (let [m (martian-http/bootstrap-openapi openapi-coercions-url)
-        default-coerce-as (:default-encoder-as martian-http/response-coerce-opts)]
+(defn do-response-coercion-test
+  [use-client-output-coercion?]
+  (let [m (martian-http/bootstrap-openapi
+            openapi-coercions-url {:use-client-output-coercion? use-client-output-coercion?})
+        default-coerce-as (:default-encoder-as
+                            (martian-http/response-coerce-opts use-client-output-coercion?))]
     (is (= "http://localhost:8888" (:api-root m)))
 
     (testing "application/edn"
@@ -347,3 +350,9 @@
              :headers {:content-type "application/json;charset=utf-8"}
              :body {:message "Here's some text content"}}
             (martian/response-for m :get-anything))))))
+
+(deftest response-coercion-test
+  (testing "without client-specific output coercion"
+    (do-response-coercion-test false))
+  (testing "with client-specific output coercion (:auto)"
+    (do-response-coercion-test true)))

--- a/hato/test/martian/hato_test.clj
+++ b/hato/test/martian/hato_test.clj
@@ -18,7 +18,6 @@
                                         create-temp-file
                                         extend-io-factory-for-path
                                         input-stream?
-                                        input-stream->byte-array
                                         without-content-type?
                                         multipart+boundary?]]
             [matcher-combinators.test])
@@ -41,7 +40,7 @@
              (-> (martian/request-for m :create-pet {:pet {:name "Doggy McDogFace"
                                                            :type "Dog"
                                                            :age 3}})
-                 (update :body #(encoders/transit-decode (input-stream->byte-array %) :msgpack))))))
+                 (update :body #(encoders/transit-decode % :msgpack))))))
 
 
     (let [response (martian/response-for m :create-pet {:pet {:name "Doggy McDogFace"
@@ -71,7 +70,7 @@
              (-> (martian/request-for m :create-pet {:pet {:name "Doggy McDogFace"
                                                            :type "Dog"
                                                            :age 3}})
-                 (update :body #(encoders/transit-decode (input-stream->byte-array %) :msgpack))))))
+                 (update :body #(encoders/transit-decode % :msgpack))))))
 
 
     (let [response @(martian/response-for m :create-pet {:pet {:name "Doggy McDogFace"

--- a/hato/test/martian/hato_test.clj
+++ b/hato/test/martian/hato_test.clj
@@ -263,8 +263,6 @@
                         :content-map {:custom (str int-num)}}}
                 (martian/response-for m :upload-data {:custom int-num}))))))))
 
-;; TODO: The `:as` value `:text` is an improper (yet valid) one for this client.
-
 (deftest response-coercion-test
   (let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
     (is (= "http://localhost:8888" (:api-root m)))
@@ -272,7 +270,7 @@
     (testing "application/edn"
       (is (match?
             {:headers {"Accept" "application/edn"}
-             :as :text}
+             :as :auto}
             (martian/request-for m :get-edn)))
       (is (match?
             {:status 200
@@ -282,7 +280,7 @@
     (testing "application/json"
       (is (match?
             {:headers {"Accept" "application/json"}
-             :as :text}
+             :as :auto}
             (martian/request-for m :get-json)))
       (is (match?
             {:status 200
@@ -292,7 +290,7 @@
     (testing "application/transit+json"
       (is (match?
             {:headers {"Accept" "application/transit+json"}
-             :as :text}
+             :as :auto}
             (martian/request-for m :get-transit+json)))
       (is (match?
             {:status 200
@@ -314,7 +312,7 @@
     (testing "application/x-www-form-urlencoded"
       (is (match?
             {:headers {"Accept" "application/x-www-form-urlencoded"}
-             :as :text}
+             :as :auto}
             (martian/request-for m :get-form-data)))
       (is (match?
             {:status 200
@@ -328,7 +326,7 @@
             (martian/handler-for m :get-something)))
       (is (match?
             {:headers {"Accept" "application/json"}
-             :as :text}
+             :as :auto}
             (martian/request-for m :get-something)))
       (is (match?
             {:status 200
@@ -345,7 +343,6 @@
             "The response auto-coercion is set")
         (is (not (contains? (:headers request) "Accept"))
             "The 'Accept' request header is absent"))
-      ;; TODO: Fails with "class clojure.lang.PersistentArrayMap cannot be cast to class java.lang.String".
       (is (match?
             {:status 200
              :headers {:content-type "application/json;charset=utf-8"}

--- a/httpkit/src/martian/httpkit.clj
+++ b/httpkit/src/martian/httpkit.clj
@@ -33,7 +33,8 @@
 (def default-interceptors
   (conj martian/default-interceptors
         (interceptors/encode-request request-encoders)
-        interceptors/default-coerce-response
+        (interceptors/coerce-response (encoders/default-encoders)
+                                      {:delegate-on-missing? false})
         perform-request))
 
 (def default-opts {:interceptors default-interceptors})
@@ -48,6 +49,7 @@
                  (fn [{:keys [body]}]
                    (if (yaml/yaml-url? url)
                      (yaml/yaml->edn body)
+                     ;; `http-kit` has no support for `:json` response coercion
                      (json/decode body keyword))))))
 
 (defn bootstrap-openapi [url & [{:keys [server-url] :as opts} load-opts]]

--- a/httpkit/src/martian/httpkit.clj
+++ b/httpkit/src/martian/httpkit.clj
@@ -33,8 +33,8 @@
 (def default-interceptors
   (conj martian/default-interceptors
         (interceptors/encode-request request-encoders)
-        (interceptors/coerce-response (encoders/default-encoders)
-                                      {:delegate-on-missing? false})
+        ;; `http-kit` does not support the `:json` response coercion
+        interceptors/default-coerce-response
         perform-request))
 
 (def default-opts {:interceptors default-interceptors})

--- a/httpkit/src/martian/httpkit.clj
+++ b/httpkit/src/martian/httpkit.clj
@@ -30,11 +30,14 @@
   (assoc (encoders/default-encoders)
     "multipart/form-data" {:encode #(encoders/multipart-encode % custom-type?)}))
 
+;; NB: `http-kit` does not support the `:json` response coercion.
+(def response-coerce-opts
+  {:default-encoder-as :text})
+
 (def default-interceptors
   (conj martian/default-interceptors
         (interceptors/encode-request request-encoders)
-        ;; `http-kit` does not support the `:json` response coercion
-        interceptors/default-coerce-response
+        (interceptors/coerce-response (encoders/default-encoders) response-coerce-opts)
         perform-request))
 
 (def default-opts {:interceptors default-interceptors})

--- a/httpkit/test/martian/httpkit_test.clj
+++ b/httpkit/test/martian/httpkit_test.clj
@@ -12,6 +12,7 @@
                                          openapi-test-yaml-url
                                          openapi-multipart-url
                                          test-multipart-file-url
+                                         openapi-coercions-url
                                          with-server]]
             [martian.test-utils :refer [create-temp-file
                                         extend-io-factory-for-path
@@ -222,7 +223,7 @@
 
 (deftest issue-189-test
   (testing "operation with '*/*' response content type"
-    (let [m (martian-http/bootstrap-openapi openapi-url {:server-url "http://localhost:8888"})]
+    (let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
       (is (match?
             {:method :get
              :url "http://localhost:8888/issue/189"

--- a/httpkit/test/martian/httpkit_test.clj
+++ b/httpkit/test/martian/httpkit_test.clj
@@ -221,15 +221,87 @@
                         :content-map {:custom (str int-num)}}}
                 @(martian/response-for m :upload-data {:custom int-num}))))))))
 
-(deftest issue-189-test
-  (testing "operation with '*/*' response content type"
-    (let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
+(deftest response-coercion-test
+  (let [m (martian-http/bootstrap-openapi openapi-coercions-url)]
+    (is (= "http://localhost:8888" (:api-root m)))
+
+    (testing "application/edn"
       (is (match?
-            {:method :get
-             :url "http://localhost:8888/issue/189"
-             :as :auto}
-            (martian/request-for m :get-something {})))
+            {:headers {"Accept" "application/edn"}
+             :as :text}
+            (martian/request-for m :get-edn)))
       (is (match?
             {:status 200
-             :body {:message "Here's some JSON content"}}
-            @(martian/response-for m :get-something {}))))))
+             :headers {:content-type "application/edn;charset=UTF-8"}
+             :body {:message "Here's some text content"}}
+            @(martian/response-for m :get-edn))))
+    (testing "application/json"
+      (is (match?
+            {:headers {"Accept" "application/json"}
+             :as :text}
+            (martian/request-for m :get-json)))
+      (is (match?
+            {:status 200
+             :headers {:content-type "application/json;charset=utf-8"}
+             :body {:message "Here's some text content"}}
+            @(martian/response-for m :get-json))))
+    (testing "application/transit+json"
+      (is (match?
+            {:headers {"Accept" "application/transit+json"}
+             :as :text}
+            (martian/request-for m :get-transit+json)))
+      (is (match?
+            {:status 200
+             :headers {:content-type "application/transit+json;charset=UTF-8"}
+             :body {:message "Here's some text content"}}
+            @(martian/response-for m :get-transit+json))))
+    (testing "application/transit+msgpack"
+      (is (match?
+            {:headers {"Accept" "application/transit+msgpack"}
+             :as :byte-array}
+            (martian/request-for m :get-transit+msgpack))
+          "The 'application/transit+msgpack' has a custom `:as` value set")
+      (is (match?
+            {:status 200
+             :headers {:content-type "application/transit+msgpack;charset=UTF-8"}
+             :body {:message "Here's some text content"}}
+            @(martian/response-for m :get-transit+msgpack))))
+    (testing "application/x-www-form-urlencoded"
+      (is (match?
+            {:headers {"Accept" "application/x-www-form-urlencoded"}
+             :as :text}
+            (martian/request-for m :get-form-data)))
+      (is (match?
+            {:status 200
+             :headers {:content-type "application/x-www-form-urlencoded"}
+             :body {:message "Here's some text content"}}
+            @(martian/response-for m :get-form-data))))
+
+    (testing "multiple response content types (default encoders order)"
+      (is (match?
+            {:produces ["application/json"]}
+            (martian/handler-for m :get-something)))
+      (is (match?
+            {:headers {"Accept" "application/json"}
+             :as :text}
+            (martian/request-for m :get-something)))
+      (is (match?
+            {:status 200
+             :headers {:content-type "application/json;charset=utf-8"}
+             :body {:message "Here's some text content"}}
+            @(martian/response-for m :get-something))))
+
+    (testing "any response content type (operation with '*/*' content)"
+      (is (match?
+            {:produces []}
+            (martian/handler-for m :get-anything)))
+      (let [request (martian/request-for m :get-anything)]
+        (is (= :auto (:as request))
+            "The response auto-coercion is set")
+        (is (not (contains? (:headers request) "Accept"))
+            "The 'Accept' request header is absent"))
+      (is (match?
+            {:status 200
+             :headers {:content-type "application/json;charset=utf-8"}
+             :body {:message "Here's some text content"}}
+            @(martian/response-for m :get-anything))))))

--- a/httpkit/test/martian/httpkit_test.clj
+++ b/httpkit/test/martian/httpkit_test.clj
@@ -219,3 +219,16 @@
                  :body {:content-type multipart+boundary?
                         :content-map {:custom (str int-num)}}}
                 @(martian/response-for m :upload-data {:custom int-num}))))))))
+
+(deftest issue-189-test
+  (testing "operation with '*/*' response content type"
+    (let [m (martian-http/bootstrap-openapi openapi-url {:server-url "http://localhost:8888"})]
+      (is (match?
+            {:method :get
+             :url "http://localhost:8888/issue/189"
+             :as :auto}
+            (martian/request-for m :get-something {})))
+      (is (match?
+            {:status 200
+             :body {:message "Here's some JSON content"}}
+            @(martian/response-for m :get-something {}))))))

--- a/httpkit/test/martian/httpkit_test.clj
+++ b/httpkit/test/martian/httpkit_test.clj
@@ -279,15 +279,15 @@
 
     (testing "multiple response content types (default encoders order)"
       (is (match?
-            {:produces ["application/json"]}
+            {:produces ["application/transit+json"]}
             (martian/handler-for m :get-something)))
       (is (match?
-            {:headers {"Accept" "application/json"}
+            {:headers {"Accept" "application/transit+json"}
              :as :text}
             (martian/request-for m :get-something)))
       (is (match?
             {:status 200
-             :headers {:content-type "application/json;charset=utf-8"}
+             :headers {:content-type "application/transit+json;charset=UTF-8"}
              :body {:message "Here's some text content"}}
             @(martian/response-for m :get-something))))
 

--- a/httpkit/test/martian/httpkit_test.clj
+++ b/httpkit/test/martian/httpkit_test.clj
@@ -19,6 +19,7 @@
                                         input-stream?
                                         without-content-type?
                                         multipart+boundary?]]
+            [matcher-combinators.matchers :as m]
             [matcher-combinators.test])
   (:import (java.io PrintWriter)
            (java.net Socket URI)
@@ -28,31 +29,28 @@
 
 (deftest swagger-http-test
   (let [m (martian-http/bootstrap-swagger swagger-url)]
-
     (testing "default encoders"
-      (is (= {:method :post
-              :url "http://localhost:8888/pets/"
-              :body {:name "Doggy McDogFace", :type "Dog", :age 3}
-              :headers {"Accept" "application/transit+msgpack"
-                        "Content-Type" "application/transit+msgpack"}
-              :as :byte-array}
-             (-> (martian/request-for m :create-pet {:pet {:name "Doggy McDogFace"
-                                                           :type "Dog"
-                                                           :age 3}})
-                 (update :body #(encoders/transit-decode % :msgpack))))))
-
-    (let [response @(martian/response-for m :create-pet {:pet {:name "Doggy McDogFace"
-                                                               :type "Dog"
-                                                               :age 3}})]
-      (is (= {:status 201
-              :body {:id 123}}
-             (select-keys response [:status :body]))))
-
-    (let [response @(martian/response-for m :get-pet {:id 123})]
-      (is (= {:name "Doggy McDogFace"
-              :type "Dog"
-              :age 3}
-             (:body response))))))
+      (is (match?
+            {:body (m/via #(encoders/transit-decode % :msgpack)
+                          {:name "Doggy McDogFace", :type "Dog", :age 3})
+             :headers {"Accept" "application/transit+msgpack"
+                       "Content-Type" "application/transit+msgpack"}
+             :as :byte-array}
+            (martian/request-for m :create-pet {:pet {:name "Doggy McDogFace"
+                                                      :type "Dog"
+                                                      :age 3}}))))
+    (testing "server responses"
+      (is (match?
+            {:status 201
+             :body {:id 123}}
+            @(martian/response-for m :create-pet {:pet {:name "Doggy McDogFace"
+                                                        :type "Dog"
+                                                        :age 3}})))
+      (is (match?
+            {:body {:name "Doggy McDogFace"
+                    :type "Dog"
+                    :age 3}}
+            @(martian/response-for m :get-pet {:id 123}))))))
 
 (deftest openapi-bootstrap-test
   (let [m (martian-http/bootstrap-openapi openapi-url)

--- a/httpkit/test/martian/httpkit_test.clj
+++ b/httpkit/test/martian/httpkit_test.clj
@@ -17,7 +17,6 @@
             [martian.test-utils :refer [create-temp-file
                                         extend-io-factory-for-path
                                         input-stream?
-                                        input-stream->byte-array
                                         without-content-type?
                                         multipart+boundary?]]
             [matcher-combinators.test])
@@ -40,7 +39,7 @@
              (-> (martian/request-for m :create-pet {:pet {:name "Doggy McDogFace"
                                                            :type "Dog"
                                                            :age 3}})
-                 (update :body #(encoders/transit-decode (input-stream->byte-array %) :msgpack))))))
+                 (update :body #(encoders/transit-decode % :msgpack))))))
 
     (let [response @(martian/response-for m :create-pet {:pet {:name "Doggy McDogFace"
                                                                :type "Dog"

--- a/test-common/martian/server_stub.clj
+++ b/test-common/martian/server_stub.clj
@@ -115,6 +115,7 @@
 (def openapi-test-yaml-url (format "http://localhost:%s/openapi-test.yaml" (::bootstrap/port service)))
 (def openapi-multipart-url (format "http://localhost:%s/openapi-multipart.json" (::bootstrap/port service)))
 (def test-multipart-file-url (format "http://localhost:%s/test-multipart.txt" (::bootstrap/port service)))
+(def openapi-coercions-url (format "http://localhost:%s/openapi-coercions.json" (::bootstrap/port service)))
 
 (defn add-interceptors
   [service-map]

--- a/test-common/martian/server_stub.clj
+++ b/test-common/martian/server_stub.clj
@@ -67,6 +67,13 @@
    :body {:content-type (get-content-type-header request)
           :content-map (get-prepared-content-map request)}})
 
+(defhandler get-something
+  {:summary   "Test case for #189"
+   :responses {200 {:body {:message s/Str}}}}
+  [request]
+  {:status 200
+   :body {:message "Here's some JSON content"}})
+
 (s/with-fn-validation
   (api/defroutes routes
     {}
@@ -82,6 +89,9 @@
 
        ;; endpoint for multipart request tests
        ["/upload" {:post upload-data}]
+
+       ;; endpoints for GitHub issues
+       ["/issue/189" {:get get-something}]
 
        ["/swagger.json" {:get api/swagger-json}]]]]))
 

--- a/test-common/martian/server_stub.clj
+++ b/test-common/martian/server_stub.clj
@@ -5,6 +5,7 @@
             [pedestal-api
              [core :as api]
              [helpers :refer [before defbefore defhandler handler]]]
+            [ring.util.codec :as codec]
             [schema.core :as s])
   (:import (java.io File)
            (java.nio.file Path)))
@@ -67,12 +68,24 @@
    :body {:content-type (get-content-type-header request)
           :content-map (get-prepared-content-map request)}})
 
+(def something
+  {:status 200
+   :body   {:message "Here's some text content"}})
+
 (defhandler get-something
-  {:summary   "Test case for #189"
+  {:summary   "Get something to test response coercion"
    :responses {200 {:body {:message s/Str}}}}
   [request]
-  {:status 200
-   :body {:message "Here's some JSON content"}})
+  something)
+
+;; Pedestal doesn't cater for form-urlencoded data
+(defhandler get-something-as-form-data
+  {:summary   "Same as `get-something`, but returns form-urlencoded data"
+   :responses {200 {:body s/Str}}}
+  [request]
+  (-> something
+      (assoc :headers {"Content-Type" "application/x-www-form-urlencoded"})
+      (update :body codec/form-encode)))
 
 (s/with-fn-validation
   (api/defroutes routes
@@ -90,8 +103,14 @@
        ;; endpoint for multipart request tests
        ["/upload" {:post upload-data}]
 
-       ;; endpoints for GitHub issues
-       ["/issue/189" {:get get-something}]
+       ;; endpoints for response coercions tests
+       ["/edn" {:get [:get-edn get-something]}]
+       ["/json" {:get [:get-json get-something]}]
+       ["/transit+json" {:get [:get-transit+json get-something]}]
+       ["/transit+msgpack" {:get [:get-transit+msgpack get-something]}]
+       ["/form-data" {:get [:get-form-data get-something-as-form-data]}]
+       ["/something" {:get [:get-something get-something]}]
+       ["/anything" {:get [:get-anything get-something]}]
 
        ["/swagger.json" {:get api/swagger-json}]]]]))
 

--- a/test-common/martian/test_utils.clj
+++ b/test-common/martian/test_utils.clj
@@ -1,18 +1,13 @@
 (ns martian.test-utils
   (:require [clojure.java.io :as io]
             [matcher-combinators.matchers :as m])
-  (:import [java.io ByteArrayOutputStream File InputStream]
+  (:import [java.io File InputStream]
            [java.nio.file Files Path]
            [java.nio.file.attribute FileAttribute]))
 
 (defmacro if-bb [then & [else]]
   (if (System/getProperty "babashka.version")
     then else))
-
-(defn input-stream->byte-array [input-stream]
-  (with-open [os (ByteArrayOutputStream.)]
-    (io/copy (io/input-stream input-stream) os)
-    (.toByteArray os)))
 
 (def input-stream? #(instance? InputStream %))
 

--- a/test-common/public/openapi-coercions.json
+++ b/test-common/public/openapi-coercions.json
@@ -8,23 +8,140 @@
         "url": "http://localhost:8888"
     }],
     "paths": {
-        "/issue/189": {
+        "/edn": {
             "get": {
-                "summary": "Test case for #189",
-                "description": "https://github.com/oliyh/martian/issues/189",
-                "operationId": "get-something",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                            }
-                        }
-                    },
-                    "required": true
-                },
+                "operationId": "get-edn",
                 "responses": {
                     "200": {
-                        "description": "Successful operation",
+                        "content": {
+                            "application/edn": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [{
+                    "api_key": []
+                }]
+            }
+        },
+        "/json": {
+            "get": {
+                "operationId": "get-json",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [{
+                    "api_key": []
+                }]
+            }
+        },
+        "/transit+json": {
+            "get": {
+                "operationId": "get-transit+json",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/transit+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [{
+                    "api_key": []
+                }]
+            }
+        },
+        "/transit+msgpack": {
+            "get": {
+                "operationId": "get-transit+msgpack",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/transit+msgpack": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [{
+                    "api_key": []
+                }]
+            }
+        },
+        "/form-data": {
+            "get": {
+                "operationId": "get-form-data",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "message": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [{
+                    "api_key": []
+                }]
+            }
+        },
+        "/something": {
+            "get": {
+                "summary": "Multiple response content types",
+                "operationId": "get-something",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/edn": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponse"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponse"
+                                }
+                            },
+                            "application/transit+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [{
+                    "api_key": []
+                }]
+            }
+        },
+        "/anything": {
+            "get": {
+                "summary": "Any response content type (issue #189)",
+                "description": "https://github.com/oliyh/martian/issues/189",
+                "operationId": "get-anything",
+                "responses": {
+                    "200": {
                         "content": {
                             "*/*": {
                                 "schema": {
@@ -47,13 +164,7 @@
                 "properties": {
                     "message": {
                         "type": "string"
-                    },
-                    "contentMap": {
-                        "type": "object"
                     }
-                },
-                "xml": {
-                    "name": "##default"
                 }
             }
         },

--- a/test-common/public/openapi-coercions.json
+++ b/test-common/public/openapi-coercions.json
@@ -1,0 +1,68 @@
+{
+    "openapi": "3.0.2",
+    "externalDocs": {
+        "description": "Find out more about Swagger",
+        "url": "http://swagger.io"
+    },
+    "servers": [{
+        "url": "http://localhost:8888"
+    }],
+    "paths": {
+        "/issue/189": {
+            "get": {
+                "summary": "Test case for #189",
+                "description": "https://github.com/oliyh/martian/issues/189",
+                "operationId": "get-something",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [{
+                    "api_key": []
+                }]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "ApiResponse": {
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    },
+                    "contentMap": {
+                        "type": "object"
+                    }
+                },
+                "xml": {
+                    "name": "##default"
+                }
+            }
+        },
+        "securitySchemes": {
+            "api_key": {
+                "type": "apiKey",
+                "name": "api_key",
+                "in": "header"
+            }
+        }
+    }
+}

--- a/test-common/public/openapi.json
+++ b/test-common/public/openapi.json
@@ -809,39 +809,6 @@
                     }
                 }
             }
-        },
-        "/issue/189": {
-            "get": {
-                "summary": "Test case for #189",
-                "description": "https://github.com/oliyh/martian/issues/189",
-                "operationId": "get-something",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "message": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [{
-                    "api_key": []
-                }]
-            }
         }
     },
     "components": {

--- a/test-common/public/openapi.json
+++ b/test-common/public/openapi.json
@@ -809,6 +809,39 @@
                     }
                 }
             }
+        },
+        "/issue/189": {
+            "get": {
+                "summary": "Test case for #189",
+                "description": "https://github.com/oliyh/martian/issues/189",
+                "operationId": "get-something",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful operation",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "message": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [{
+                    "api_key": []
+                }]
+            }
         }
     },
     "components": {


### PR DESCRIPTION
**In Scope:**

- #232
- #234
- #233
- #189
- #58
- #237
- #236

**Notes:**

These all are closely related, and it's super hard to fix them individually while preserving logical completeness, correctness and some basic compatibility. For instance, when one fixes #232, everything else starts to fall apart because an encoder for a specific "Content-Type" now gets detected and the "two negatives make an affirmative" rule stops working for us! 😫 

That said, I decided to ship everything together, but in a gradual way (which someone may call "TDD").

First, I introduce a missing test coverage for all target HTTP clients and supported content types (and the `"*/*"` OpenAPI/Swagger response content special case). I also put a number of ToDo items in tests for all the issues I've found. Please, note that the new tests for the issues in scope are expected to fail!

Second, implement and roll out all the fixes.

Third, augment the existing test coverage to nail down the results of the fix and/or to highlight potential compatibility issues. Here I don't add new test cases, but rather introduce additional checks for existing ones.

Finally, I clean up the tests code a bit after relaxing some constraints that are no longer needed; add test coverage for both ways of using `clj-http` and `hato` clients (with `:auto`-coercions on and off); and expose new Martian bootstrap options, namely `:use-client-output-coercion?` and `:async?`, for capable clients.