### PR TITLE
Handle invalid handlers properly

### DIFF
--- a/core/src/martian/core.cljc
+++ b/core/src/martian/core.cljc
@@ -105,9 +105,7 @@
   ([martian route-name params]
    (let [{:keys [handlers interceptors opts] :as martian} (resolve-instance martian)]
      (when-let [handler (find-handler handlers route-name)]
-       (let [ctx (tc/enqueue* {} (-> (or interceptors default-interceptors)
-                                     (vec)
-                                     (conj interceptors/request-only-handler)))]
+       (let [ctx (tc/enqueue* {} (conj interceptors interceptors/request-only-handler))]
          (:request (tc/execute
                     (assoc ctx
                            :url-for (partial url-for martian)
@@ -123,7 +121,7 @@
   ([martian route-name params]
    (let [{:keys [handlers interceptors opts] :as martian} (resolve-instance martian)]
      (when-let [handler (find-handler handlers route-name)]
-       (let [ctx (tc/enqueue* {} (or interceptors default-interceptors))]
+       (let [ctx (tc/enqueue* {} interceptors)]
          (:response (tc/execute
                      (assoc ctx
                             :url-for (partial url-for martian)
@@ -188,7 +186,7 @@
                                   validate-handlers? (validate-all-handlers!))]
     (->Martian api-root
                enriched-handlers
-               (or interceptors default-interceptors)
+               (vec (or interceptors default-interceptors))
                (dissoc opts :interceptors))))
 
 (spec/fdef build-instance

--- a/core/src/martian/core.cljc
+++ b/core/src/martian/core.cljc
@@ -12,21 +12,10 @@
             [martian.swagger :refer [swagger->handlers]]
             [tripod.context :as tc]))
 
-#?(:bb
-   ;; reflection issue in babashka -- TODO, submit patch upstream?
-   (do (defn- exception->ex-info [^Throwable exception execution-id interceptor stage]
-         (ex-info (str "Interceptor Exception: " #?(:clj  (.getMessage exception)
-                                                    :cljs (.-message exception)))
-                  (merge {:execution-id execution-id
-                          :stage        stage
-                          :interceptor  (:name interceptor)
-                          :type         (type exception)
-                          :exception    exception}
-                         (ex-data exception))
-                  exception))
-       (alter-var-root #'tc/exception->ex-info (constantly exception->ex-info))))
+(defrecord Martian [api-root handlers interceptors opts])
 
 (def default-interceptors
+  "The vector with default interceptors used to build a Martian instance."
   [interceptors/keywordize-params
    interceptors/set-method
    interceptors/set-url
@@ -36,9 +25,12 @@
    interceptors/set-header-params
    interceptors/enqueue-route-specific-interceptors])
 
-(def default-coercion-matcher schema/default-coercion-matcher)
+(def default-coercion-matcher
+  "The default coercion matcher used by Martian for parameters coercion."
+  schema/default-coercion-matcher)
 
-(def ^:private parameter-schemas [:path-schema :query-schema :body-schema :form-schema :headers-schema])
+(def ^:private parameter-schemas
+  [:path-schema :query-schema :body-schema :form-schema :headers-schema])
 
 (defn- resolve-instance [m]
   (cond
@@ -57,62 +49,78 @@
 (defn- matching-handler? [route-name handler]
   (= (keyword route-name) (:route-name handler)))
 
-(defn find-handler [handlers route-name]
+(defn- find-handler [handlers route-name]
   (or (some-> (some #(when (matching-handler? route-name %) %) handlers)
               (validate-handler!))
       (throw (ex-info (str "Could not find route " route-name)
                       {:route-name route-name
                        :handlers handlers}))))
 
-(defn handler-for [m route-name]
-  (find-handler (:handlers (resolve-instance m)) route-name))
+(defn handler-for
+  "Given a Martian instance, returns a handler for the given `route-name`."
+  [martian route-name]
+  (find-handler (:handlers (resolve-instance martian)) route-name))
 
 (defn update-handler
-  "Update a handler in the martian record with the provided route-name
-   e.g. add route-specific interceptors:
-   (update-handler m :load-pet assoc :interceptors [an-interceptor])"
-  [m route-name update-fn & update-args]
-  (update (resolve-instance m)
+  "Given a Martian instance, updates a handler with the provided `route-name`
+   using the provided `update-fn` and `update-args`, if any.
+
+   For example, route-specific interceptors can be added like that:
+   ```
+   (update-handler m :load-pet assoc :interceptors [an-interceptor])
+   ```"
+  [martian route-name update-fn & update-args]
+  (update (resolve-instance martian)
           :handlers #(mapv (fn [handler]
                              (if (matching-handler? route-name handler)
                                (apply update-fn handler update-args)
                                handler))
                            %)))
 
-(defrecord Martian [api-root handlers interceptors opts])
-
 (defn url-for
+  "Given a Martian instance, builds a request URL for the given `route-name`
+   using the provided `params` and options, if any.
+
+   Supported options:
+   - `:include-query?` — if true, will include params in the URL query string;
+                         false by default."
   ([martian route-name] (url-for martian route-name {}))
   ([martian route-name params] (url-for martian route-name params {}))
-  ([martian route-name params opts]
-   (let [{:keys [api-root handlers]} (resolve-instance martian)]
+  ([martian route-name params {:keys [include-query?] :as _options}]
+   (let [{:keys [api-root handlers opts]} (resolve-instance martian)]
      (when-let [handler (find-handler handlers route-name)]
-       (let [path-params (interceptors/coerce-data handler :path-schema (keywordize-keys params) (:opts martian))
-             query-params (when (:include-query? opts)
-                            (interceptors/coerce-data handler :query-schema (keywordize-keys params) (:opts martian)))]
+       (let [path-params (interceptors/coerce-data handler :path-schema (keywordize-keys params) opts)
+             query-params (when include-query?
+                            (interceptors/coerce-data handler :query-schema (keywordize-keys params) opts))]
          (str api-root (string/join (map #(get path-params % %) (:path-parts handler)))
               (if query-params
                 (str "?" (map->query-string query-params))
                 "")))))))
 
 (defn request-for
+  "Given a Martian instance, builds an HTTP request for the given `route-name`
+   using the provided `params`, if any."
   ([martian route-name] (request-for martian route-name {}))
   ([martian route-name params]
-   (let [{:keys [handlers interceptors] :as martian} (resolve-instance martian)]
+   (let [{:keys [handlers interceptors opts] :as martian} (resolve-instance martian)]
      (when-let [handler (find-handler handlers route-name)]
-       (let [ctx (tc/enqueue* {} (-> (or interceptors default-interceptors) vec (conj interceptors/request-only-handler)))]
+       (let [ctx (tc/enqueue* {} (-> (or interceptors default-interceptors)
+                                     (vec)
+                                     (conj interceptors/request-only-handler)))]
          (:request (tc/execute
                     (assoc ctx
                            :url-for (partial url-for martian)
                            :request (or (::request params) {})
                            :handler handler
                            :params params
-                           :opts (:opts martian)))))))))
+                           :opts opts))))))))
 
 (defn response-for
+  "Given a Martian instance, makes an HTTP request for the given `route-name`
+   using the provided `params`, if any, and returns the HTTP response."
   ([martian route-name] (response-for martian route-name {}))
   ([martian route-name params]
-   (let [{:keys [handlers interceptors] :as martian} (resolve-instance martian)]
+   (let [{:keys [handlers interceptors opts] :as martian} (resolve-instance martian)]
      (when-let [handler (find-handler handlers route-name)]
        (let [ctx (tc/enqueue* {} (or interceptors default-interceptors))]
          (:response (tc/execute
@@ -121,24 +129,35 @@
                             :request (or (::request params) {})
                             :handler handler
                             :params params
-                            :opts (:opts martian)))))))))
+                            :opts opts))))))))
 
 (declare explore)
+
 (defn- navize-routes
   [martian routes]
   (with-meta
     routes
-    {`clojure.core.protocols/nav
-     (fn [_coll _k [route-name _route-description]]
-       (explore martian route-name))}))
+    {`clojure.core.protocols/nav (fn [_coll _k [route-name _summary]]
+                                   (explore martian route-name))}))
 
 (defn explore
-  ([martian] (navize-routes martian (mapv (juxt :route-name :summary) (:handlers (resolve-instance martian)))))
+  "Explores the given Martian instance or a particular handler with the given
+   `route-name`, if any.
+
+   Returns a map containing details such as:
+   - `:route-name` and `:summary` — for the Martian instance, or
+   - `:summary`, `:parameters`, and `:returns` — for the handler."
+  ([martian]
+   (let [routes (mapv (juxt :route-name :summary)
+                      (:handlers (resolve-instance martian)))]
+     (navize-routes martian routes)))
   ([martian route-name]
-   (when-let [{:keys [parameter-aliases summary deprecated?] :as handler} (find-handler (:handlers (resolve-instance martian)) route-name)]
+   (when-let [{:keys [parameter-aliases summary deprecated?] :as handler} (handler-for martian route-name)]
      (-> {:summary summary
           :parameters (reduce (fn [params parameter-key]
-                                (merge params (alias-schema (get parameter-aliases parameter-key) (get handler parameter-key))))
+                                (merge
+                                  params
+                                  (alias-schema (get parameter-aliases parameter-key) (get handler parameter-key))))
                               {}
                               parameter-schemas)
           :returns (->> (:response-schemas handler)
@@ -159,7 +178,8 @@
               (assoc handler :exception ex))))
         handlers))
 
-(defn- build-instance [api-root handlers {:keys [interceptors validate-handlers?] :as opts}]
+(defn- build-instance
+  [api-root handlers {:keys [interceptors validate-handlers?] :as opts}]
   (let [enriched-handlers (enrich-handlers handlers)]
     (when validate-handlers?
       (doseq [handler enrich-handlers]
@@ -175,7 +195,19 @@
                   :opts ::mspec/opts))
 
 (defn bootstrap-openapi
-  "Creates a martian instance from an OpenAPI/Swagger spec based on the schema provided"
+  "Creates a Martian instance from an OpenAPI/Swagger spec based on the `json`
+   schema provided.
+
+   Supported options:
+   - `:interceptors`       — an ordered coll of Tripod interceptors to be used
+                             as a global interceptor chain by Martian instance;
+                             defaults to the `default-interceptors`;
+   - `:validate-handlers?` — if true, will enable early validation of handlers,
+                             failing fast in case of errors; false by default;
+   - `:coercion-matcher`   — a unary fn of schema used for parameters coercion;
+                             defaults to the `default-coercion-matcher`;
+   - `:use-defaults?`      — if true, will read 'default' directives from the
+                             OpenAPI/Swagger spec; false by default."
   [api-root json & [opts]]
   (let [{:keys [interceptors] :or {interceptors default-interceptors} :as opts} (keywordize-keys opts)
         handlers (if (openapi-schema? json)
@@ -183,10 +215,39 @@
                    (swagger->handlers json))]
     (build-instance api-root handlers opts)))
 
-(def bootstrap-swagger bootstrap-openapi)
+(def
+  ^{:doc "Creates a Martian instance from an OpenAPI/Swagger spec based on the `json`
+   schema provided.
+
+   Supported options:
+   - `:interceptors`       — an ordered coll of Tripod interceptors to be used
+                             as a global interceptor chain by Martian instance;
+                             defaults to the `default-interceptors`;
+   - `:validate-handlers?` — if true, will enable early validation of handlers,
+                             failing fast in case of errors; false by default;
+   - `:coercion-matcher`   — a unary fn of schema used for parameters coercion;
+                             defaults to the `default-coercion-matcher`;
+   - `:use-defaults?`      — if true, will read 'default' directives from the
+                             OpenAPI/Swagger spec; false by default."
+    :arglists '([api-root json & [opts]])}
+  bootstrap-swagger
+  bootstrap-openapi)
 
 (defn bootstrap
-  "Creates a martian instance from a martian description"
+  "Creates a Martian instance from the given `concise-handlers` description.
+
+   Supported options:
+   - `:interceptors`       — an ordered coll of Tripod interceptors to be used
+                             as a global interceptor chain by Martian instance;
+                             defaults to the `default-interceptors`;
+   - `:validate-handlers?` — if true, will enable early validation of handlers,
+                             failing fast in case of errors; false by default;
+   - `:coercion-matcher`   — a unary fn of schema used for parameters coercion;
+                             defaults to the `default-coercion-matcher`;
+   - `:produces`           — a coll of media (content) types used as a global
+                             default value for the handler's `:produces` key;
+   - `:consumes`           — a coll of media (content) types used as a global
+                             default value for the handler's `:consumes` key."
   [api-root concise-handlers & [{:keys [produces consumes] :as opts}]]
   (let [handlers (map (fn [handler]
                         (-> handler

--- a/core/src/martian/core.cljc
+++ b/core/src/martian/core.cljc
@@ -64,8 +64,11 @@
     (fn? m) (m)
     :else m))
 
+(defn- matching-handler? [route-name handler]
+  (= (keyword route-name) (:route-name handler)))
+
 (defn find-handler [handlers route-name]
-  (or (first (filter #(= (keyword route-name) (:route-name %)) handlers))
+  (or (some #(when (matching-handler? route-name %) %) handlers)
       (throw (ex-info (str "Could not find route " route-name)
                       {:handlers   handlers
                        :route-name route-name}))))
@@ -80,7 +83,7 @@
   [m route-name update-fn & update-args]
   (update (resolve-instance m)
           :handlers #(mapv (fn [handler]
-                             (if (= (keyword route-name) (:route-name handler))
+                             (if (matching-handler? route-name handler)
                                (apply update-fn handler update-args)
                                handler))
                            %)))

--- a/core/src/martian/interceptors.cljc
+++ b/core/src/martian/interceptors.cljc
@@ -9,6 +9,20 @@
             [schema.core :as s]
             [tripod.context :as tc]))
 
+#?(:bb
+   ;; reflection issue in babashka -- TODO, submit patch upstream?
+   (do (defn- exception->ex-info [^Throwable exception execution-id interceptor stage]
+         (ex-info (str "Interceptor Exception: " #?(:clj  (.getMessage exception)
+                                                    :cljs (.-message exception)))
+                  (merge {:execution-id execution-id
+                          :stage        stage
+                          :interceptor  (:name interceptor)
+                          :type         (type exception)
+                          :exception    exception}
+                         (ex-data exception))
+                  exception))
+       (alter-var-root #'tc/exception->ex-info (constantly exception->ex-info))))
+
 (defn remove-stack [ctx]
   (-> ctx tc/terminate (dissoc ::tc/stack)))
 

--- a/core/src/martian/spec.cljc
+++ b/core/src/martian/spec.cljc
@@ -16,9 +16,9 @@
 (s/def ::form-schema ::input-schema)
 (s/def ::headers-schema ::input-schema)
 
-(s/def ::content-types (s/nilable (s/coll-of string?)))
-(s/def ::produces ::content-types)
-(s/def ::consumes ::content-types)
+(s/def ::media-types (s/nilable (s/coll-of string?)))
+(s/def ::produces ::media-types)
+(s/def ::consumes ::media-types)
 
 (s/def ::handler
   (s/keys
@@ -42,6 +42,13 @@
 
 (s/def ::interceptor (s/keys :opt-un [::name ::enter ::leave ::catch]))
 (s/def ::interceptors (s/nilable (s/coll-of ::interceptor)))
+(s/def ::coercion-matcher fn?)
 (s/def ::use-defaults? boolean?)
+(s/def ::validate-handlers? boolean?)
 
-(s/def ::opts (s/nilable (s/keys :opt-un [::interceptors ::use-defaults?])))
+(s/def ::opts (s/nilable (s/keys :opt-un [::interceptors
+                                          ::produces
+                                          ::consumes
+                                          ::coercion-matcher
+                                          ::use-defaults?
+                                          ::validate-handlers?])))

--- a/test/src/martian/test.cljc
+++ b/test/src/martian/test.cljc
@@ -56,8 +56,8 @@
    :leave (fn [ctx]
             (assoc ctx :response (response-fn ctx)))})
 
-(defn response-generator [{:keys [handlers]} route-name]
-  (let [{:keys [response-schemas]} (martian/find-handler handlers route-name)]
+(defn response-generator [martian route-name]
+  (let [{:keys [response-schemas]} (martian/handler-for martian route-name)]
     (make-generator :random response-schemas)))
 
 #?(:clj


### PR DESCRIPTION
@oliyh Hi Oliver!

I came across another subtle issue (sorry!) in the current implementation of the Martian core module.

The original error — recently discovered in my own project, which uses Martian quite extensively — was rather cryptic:

```clojure
...
Caused by: java.lang.IllegalArgumentException: No implementation of method: :spec of protocol: #'schema.core/Schema found for class: nil
 at clojure.core$_cache_protocol_fn.invokeStatic (core_deftype.clj:585)
    clojure.core$_cache_protocol_fn.invoke (core_deftype.clj:577)
    schema.core$eval6697$fn__6709$G__6686__6714.invoke (core.cljc:96)
    martian.schema_tools$with_paths.invokeStatic (schema_tools.cljc:18)
    martian.schema_tools$with_paths.invoke (schema_tools.cljc:9)
    martian.schema_tools$key_seqs.invokeStatic (schema_tools.cljc:28)
    martian.schema_tools$key_seqs.invoke (schema_tools.cljc:20)
    martian.parameter_aliases$parameter_aliases.invokeStatic (parameter_aliases.cljc:26)
    martian.parameter_aliases$parameter_aliases.invoke (parameter_aliases.cljc:16)
    martian.core$enrich_handler$fn__9212.invoke (core.cljc:47)
    clojure.lang.PersistentVector.reduce (PersistentVector.java:418)
    clojure.core$reduce.invokeStatic (core.clj:6964)
    clojure.core$reduce.invoke (core.clj:6947)
    martian.core$enrich_handler.invokeStatic (core.cljc:46)
    martian.core$enrich_handler.invoke (core.cljc:43)
    clojure.core$comp$fn__5897.invoke (core.clj:2586)
    clojure.core$map$fn__5956.invoke (core.clj:2770)
    clojure.lang.LazySeq.force (LazySeq.java:50)
    clojure.lang.LazySeq.realize (LazySeq.java:89)
    clojure.lang.LazySeq.seq (LazySeq.java:106)
    clojure.lang.RT.seq (RT.java:555)
    clojure.core$seq__5488.invokeStatic (core.clj:139)
    clojure.core$filter$fn__5983.invoke (core.clj:2826)
    clojure.lang.LazySeq.force (LazySeq.java:50)
    clojure.lang.LazySeq.lockAndForce (LazySeq.java:60)
    clojure.lang.LazySeq.sval (LazySeq.java:69)
    clojure.lang.LazySeq.unwrap (LazySeq.java:77)
    clojure.lang.LazySeq.realize (LazySeq.java:93)
    clojure.lang.LazySeq.seq (LazySeq.java:106)
    clojure.lang.LazySeq.first (LazySeq.java:118)
    clojure.lang.RT.first (RT.java:712)
    clojure.core$first__5470.invokeStatic (core.clj:55)
    clojure.core/first (core.clj:55)
    martian.core$find_handler.invokeStatic (core.cljc:68)
    martian.core$find_handler.invoke (core.cljc:67)
    martian.core$response_for.invokeStatic (core.cljc:122)
    martian.core$response_for.invoke (core.cljc:118)
    ...
```

Apparently, there was something wrong with the schema of one (or maybe more — who knows?) of my many handlers. But tracing the exact origin of the exception turned out to be quite difficult, as all contextual information about the error was already lost. 😩

What immediately stood out was that the error occurred the *first time* I interacted with an otherwise **successfully (!)** bootstrapped Martian instance. After some debugging, I realized that the current design is inherently prone to this kind of issue, since handlers are/can be initialized lazily and such errors can’t be addressed by simply wrapping code in a `try`/`catch` (say, inside a `filter` predicate of the `find-handler` fn), but at the same time there’s no built-in realization-for-validation mechanism that could carry an exception across lazy execution boundaries and circumvent this information loss problem.

What confused me even more, given Clojure’s "lazy by default" nature and lazy sequences realization in relatively large chunks of 32, was that a bug in *any single handler* can render *other perfectly valid handlers* unusable. That’s a pretty glaring design flaw, tbh. In certain situations you still want to be able to use working handlers (e.g. if you are ok with having a working subset and/or you are not responsible for the whole thing to work, which is usually the case when you consume someone else's OpenAPI/Swagger spec via Martian), in others it is preferable to throw an exception early on, during the instance bootstrapping (e.g. if you are in charge for something as a working whole, which is usually the case if you're building an API client library atop of Martian).

Given all that, adding explicit handler validation suggests itself. However, since the current behaviour defers any errors in handler initialization/realization — and since early validation of handlers *may not be desirable at all*, as already mentioned — the new feature needs to be both **opt-in** and **backwards-compatible**. Hence the new option `:validate-handlers?`, which defaults to `false`.

---

**How it will work after the proposed changes**

1. Default behaviour (do not validate, backward compatible):

```clojure
(martian/bootstrap api-root handlers)
=>
#martian.core.Martian{:api-root ..., :handlers ...} ; bootstrapped, no problemo

(martian/handler-for client :valid-handler-route)   ; or any other `core` fn call for a valid handler
=>
{:route-name :valid-handler-route, ...}

(martian/handler-for client :invalid-handler-route) ; or any other `core` fn call for an invalid handler
=>
clojure.lang.ExceptionInfo: Invalid handler for route :invalid-handler-route
{:handler {..., :body-schema {:body {..., #schema.core.OptionalKey{:k :failing_key} nil}}, :exception #error {
 :cause "No implementation of method: :spec of protocol: #'schema.core/Schema found for class: nil"
 :via
 [{:type java.lang.IllegalArgumentException
   :message "No implementation of method: :spec of protocol: #'schema.core/Schema found for class: nil"
   :at [clojure.core$_cache_protocol_fn invokeStatic "core_deftype.clj" 585]}]
 :trace
 [...
  [martian.core$enrich_handler invokeStatic "core.cljc" 175]
  [martian.core$enrich_handler invoke "core.cljc" 174]
  ...
  [martian.core$build_instance invokeStatic "core.cljc" 189]
  [martian.core$build_instance invoke "core.cljc" 187]
  [martian.core$bootstrap invokeStatic "core.cljc" 261]
  [martian.core$bootstrap doInvoke "core.cljc" 240]
  ...
```

2. Early validation upon bootstrapping (with the new option):

```clojure
(martian/bootstrap api-root handlers {:validate-handlers? true})
=>
clojure.lang.ExceptionInfo: Invalid handlers
{:handlers ({..., :body-schema {:body {..., #schema.core.OptionalKey{:k :failing_key} nil}}, :exception #error {
 :cause "No implementation of method: :spec of protocol: #'schema.core/Schema found for class: nil"
 :via
 [{:type java.lang.IllegalArgumentException
   :message "No implementation of method: :spec of protocol: #'schema.core/Schema found for class: nil"
   :at [clojure.core$_cache_protocol_fn invokeStatic "core_deftype.clj" 585]}]
 :trace
 [...
  [martian.core$enrich_handler invokeStatic "core.cljc" 175]
  [martian.core$enrich_handler invoke "core.cljc" 174]
  ...
  [martian.core$build_instance invokeStatic "core.cljc" 189]
  [martian.core$build_instance invoke "core.cljc" 187]
  [martian.core$bootstrap invokeStatic "core.cljc" 261]
  [martian.core$bootstrap doInvoke "core.cljc" 240]
  ...
```

The error context is preserved in both cases, and in the second case _all invalid handlers_ are also passed on.

As part of this PR, I also gave the `martian.core` namespace [a little facelift](https://github.com/oliyh/martian/pull/239/commits/01bc4938a9e7071ad207f2af34c4b78e24e6f676) to improve usability/DX just a bit.

Cheers,
Mark