### PR TITLE
Add default content types

### DIFF
--- a/babashka-http-client/test/martian/babashka/http_client_test.clj
+++ b/babashka-http-client/test/martian/babashka/http_client_test.clj
@@ -306,22 +306,30 @@
       (is (= {:encodes ["application/transit+json"
                         "application/edn"
                         "application/json"
-                        "multipart/form-data"]
+                        "multipart/form-data"
+                        "text/plain"
+                        "application/octet-stream"]
               :decodes ["application/transit+json"
                         "application/edn"
-                        "application/json"]}
+                        "application/json"
+                        "text/plain"
+                        "application/octet-stream"]}
              (i/supported-content-types (:interceptors m))))
       (is (= {:encodes ["application/transit+msgpack"
                         "application/transit+json"
                         "application/edn"
                         "application/json"
                         "application/x-www-form-urlencoded"
-                        "multipart/form-data"]
+                        "multipart/form-data"
+                        "text/plain"
+                        "application/octet-stream"]
               :decodes ["application/transit+msgpack"
                         "application/transit+json"
                         "application/edn"
                         "application/json"
-                        "application/x-www-form-urlencoded"]}
+                        "application/x-www-form-urlencoded"
+                        "text/plain"
+                        "application/octet-stream"]}
              (i/supported-content-types (:interceptors m)))))))
 
 (deftest response-coercion-test

--- a/cljs-http-promise/test/martian/cljs_http_promise_test.cljs
+++ b/cljs-http-promise/test/martian/cljs_http_promise_test.cljs
@@ -83,11 +83,15 @@
           (is (= {:encodes ["application/transit+json"
                             "application/edn"
                             "application/json"
-                            "application/x-www-form-urlencoded"]
+                            "application/x-www-form-urlencoded"
+                            "text/plain"
+                            "application/octet-stream"]
                   :decodes ["application/transit+json"
                             "application/edn"
                             "application/json"
-                            "application/x-www-form-urlencoded"]}
+                            "application/x-www-form-urlencoded"
+                            "text/plain"
+                            "application/octet-stream"]}
                  (i/supported-content-types (:interceptors m)))))
         (prom/catch report-error-and-throw)
         (prom/finally (fn []

--- a/cljs-http/test/martian/cljs_http_test.cljs
+++ b/cljs-http/test/martian/cljs_http_test.cljs
@@ -67,11 +67,15 @@
           (is (= {:encodes ["application/transit+json"
                             "application/edn"
                             "application/json"
-                            "application/x-www-form-urlencoded"]
+                            "application/x-www-form-urlencoded"
+                            "text/plain"
+                            "application/octet-stream"]
                   :decodes ["application/transit+json"
                             "application/edn"
                             "application/json"
-                            "application/x-www-form-urlencoded"]}
+                            "application/x-www-form-urlencoded"
+                            "text/plain"
+                            "application/octet-stream"]}
                  (i/supported-content-types (:interceptors m)))))
         (done))))
 

--- a/core/src/martian/interceptors.cljc
+++ b/core/src/martian/interceptors.cljc
@@ -187,17 +187,21 @@
                                   :response-schemas (:response-schemas handler)}))))
              ctx)}))
 
+(def prepare-content-types
+  (comp vec distinct #(into % ["text/plain" "application/octet-stream"])))
+
 (defn supported-content-types
-  "Return the full set of supported content-types as declared by any encoding/decoding interceptors,
-   preserving their original declaration order."
+  "Returns the full set of supported content-types used for parsing OpenAPI spec
+   as declared by any encoding/decoding interceptors, preserving their original
+   declaration order and appending the default ones."
   [interceptors]
   (-> (reduce (fn [acc interceptor]
                 (merge-with into acc (select-keys interceptor [:encodes :decodes])))
               {:encodes []
                :decodes []}
               interceptors)
-      (update :encodes distinct)
-      (update :decodes distinct)))
+      (update :encodes prepare-content-types)
+      (update :decodes prepare-content-types)))
 
 ;; borrowed from https://github.com/walmartlabs/lacinia-pedestal/blob/master/src/com/walmartlabs/lacinia/pedestal.clj#L40
 (defn inject
@@ -234,5 +238,4 @@
                        :new-interceptor new-interceptor
                        :relative-position relative-position
                        :interceptor-name interceptor-name})))
-
     final-result))

--- a/core/test/martian/interceptors_test.cljc
+++ b/core/test/martian/interceptors_test.cljc
@@ -268,31 +268,43 @@
 
       (is (= {:encodes #?(:bb   ["application/transit+json"
                                  "application/edn"
-                                 "application/json"]
+                                 "application/json"
+                                 "text/plain"
+                                 "application/octet-stream"]
                           :clj  ["application/transit+msgpack"
                                  "application/transit+json"
                                  "application/edn"
                                  "application/json"
-                                 "application/x-www-form-urlencoded"]
+                                 "application/x-www-form-urlencoded"
+                                 "text/plain"
+                                 "application/octet-stream"]
                           :cljs ["application/transit+json"
                                  "application/edn"
                                  "application/json"
-                                 "application/x-www-form-urlencoded"])
+                                 "application/x-www-form-urlencoded"
+                                 "text/plain"
+                                 "application/octet-stream"])
               :decodes #?(:bb   ["application/transit+json"
                                  "application/edn"
                                  "application/json"
-                                 "text/magical+json"]
+                                 "text/magical+json"
+                                 "text/plain"
+                                 "application/octet-stream"]
                           :clj  ["application/transit+msgpack"
                                  "application/transit+json"
                                  "application/edn"
                                  "application/json"
                                  "application/x-www-form-urlencoded"
-                                 "text/magical+json"]
+                                 "text/magical+json"
+                                 "text/plain"
+                                 "application/octet-stream"]
                           :cljs ["application/transit+json"
                                  "application/edn"
                                  "application/json"
                                  "application/x-www-form-urlencoded"
-                                 "text/magical+json"])}
+                                 "text/magical+json"
+                                 "text/plain"
+                                 "application/octet-stream"])}
              (i/supported-content-types [encode-request coerce-response]))))))
 
 (deftest validate-response-test


### PR DESCRIPTION
@oliyh Hi Oliver!

This PR updates the **supported content types for OpenAPI specs** with the default ones.

The `"text/plain"` and `"application/octet-stream"` are the [default mime types of the web](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types#important_mime_types_for_web_developers).
These are de facto supported by each and every HTTP client, including the target ones.
Hence, no specific treatment needs to be added on the Martian's side to process these.

The PR addresses:
- the last bit of the issue #58, and
- combined with #240, it also reduces noise in logs (#214).

Hope that helps!

Cheers,
Mark