### PR TITLE
Fix nested param aliases

### DIFF
--- a/core/src/martian/parameter_aliases.cljc
+++ b/core/src/martian/parameter_aliases.cljc
@@ -2,13 +2,17 @@
   (:require [schema.core :as s]
             [camel-snake-kebab.core :refer [->kebab-case]]
             [clojure.set :refer [rename-keys]]
-            [martian.schema-tools :refer [key-seqs prewalk-with-path]]))
+            [martian.schema-tools :refer [unspecify-key key-seqs prewalk-with-path]]))
 
-;; todo lean on schema-tools.core for some of this
+;; TODO: Lean on `schema-tools.core` for some of these transformations.
+
+(defn can-be-kebabised? [k]
+  (not (and (keyword? k) (namespace k))))
 
 (defn ->idiomatic [k]
-  (when (and k (s/specific-key? k) (not (and (keyword? k) (namespace k))))
-    (->kebab-case (s/explicit-schema-key k))))
+  (when-some [uk (when k (unspecify-key k))]
+    (when (can-be-kebabised? uk)
+      (->kebab-case uk))))
 
 (defn- idiomatic-path [path]
   (vec (keep ->idiomatic path)))

--- a/core/src/martian/parameter_aliases.cljc
+++ b/core/src/martian/parameter_aliases.cljc
@@ -1,10 +1,8 @@
 (ns martian.parameter-aliases
-  (:require [schema.core :as s]
-            [camel-snake-kebab.core :refer [->kebab-case]]
+  (:require [camel-snake-kebab.core :refer [->kebab-case]]
             [clojure.set :refer [rename-keys]]
-            [martian.schema-tools :refer [unspecify-key key-seqs prewalk-with-path]]))
-
-;; TODO: Lean on `schema-tools.core` for some of these transformations.
+            [martian.schema-tools :refer [unspecify-key key-seqs prewalk-with-path]]
+            [schema.core :as s]))
 
 (defn can-be-kebabised? [k]
   (not (and (keyword? k) (namespace k))))
@@ -18,7 +16,10 @@
   (vec (keep ->idiomatic path)))
 
 (defn parameter-aliases
-  "Produces a data structure for use with `unalias-data`"
+  "Produces a data structure with idiomatic keys (aliases) mappings per path
+   in a (possibly, deeply nested) `schema` for all its unqualified keys.
+
+   The result is then used with `alias-schema` and `unalias-data` functions."
   [schema]
   (reduce (fn [acc path]
             (if-let [idiomatic-key (some-> path last ->idiomatic)]
@@ -30,7 +31,8 @@
           (key-seqs schema)))
 
 (defn unalias-data
-  "Takes parameter aliases and (deeply nested) data, returning data with deeply-nested keys renamed as described by parameter-aliases"
+  "Given a (possibly, deeply nested) data `x`, returns the data with all keys
+   renamed as described by the `parameter-aliases`."
   [parameter-aliases x]
   (if parameter-aliases
     (prewalk-with-path (fn [path x]
@@ -42,7 +44,9 @@
     x))
 
 (defn alias-schema
-  "Walks a schema, transforming all keys into their aliases (idiomatic keys)"
+  "Given a (possibly, deeply nested) `schema`, renames all keys (in it and its
+   subschemas) into corresponding idiomatic keys (aliases) as described by the
+   `parameter-aliases`."
   [parameter-aliases schema]
   (if parameter-aliases
     (prewalk-with-path (fn [path x]

--- a/core/src/martian/schema_tools.cljc
+++ b/core/src/martian/schema_tools.cljc
@@ -4,8 +4,6 @@
             [schema.spec.core :as spec])
   #?(:clj (:import [schema.core MapEntry EqSchema])))
 
-;; TODO: Cover `key-seqs` and `walk-with-path` functions with some tests.
-
 (defn unspecify-key [k]
   (if (s/specific-key? k)
     (s/explicit-schema-key k)
@@ -51,6 +49,8 @@
         (distinct paths)))))
 
 ;;
+
+;; TODO: Cover the `walk-with-path` function with some tests.
 
 (defn walk-with-path
   "Similar to the `schema-tools.walk/walk` except it keeps track of the `path`

--- a/core/src/martian/schema_tools.cljc
+++ b/core/src/martian/schema_tools.cljc
@@ -1,8 +1,11 @@
 (ns martian.schema-tools
   (:require [flatland.ordered.set :refer [ordered-set]]
             [schema.core :as s #?@(:cljs [:refer [MapEntry EqSchema]])]
+            [schema-tools.impl :as sti]
             [schema.spec.core :as spec])
   #?(:clj (:import [schema.core MapEntry EqSchema])))
+
+;; TODO: Cover `key-seqs` and `walk-with-path` functions with some tests.
 
 (defn unspecify-key [k]
   (if (s/specific-key? k)
@@ -37,7 +40,8 @@
          (remove nil?))))
 
 (defn key-seqs
-  "Returns a collection of paths which would address all possible entries (using `get-in`) in data described by the schema"
+  "Returns a vec of paths (key seqs) which would address all possible entries
+   in a data described by the `schema`."
   [schema]
   (when (map? schema)
     (loop [paths (ordered-set [])
@@ -49,11 +53,10 @@
 
 ;;
 
-;; TODO: Cover with more tests and lean on the `schema-tools.walk` if possible.
-
 (defn walk-with-path
-  "Identical to `clojure.walk/walk` except keeps track of the path through the data structure (as per `get-in`)
-   as it goes, calling `inner` and `outer` with two args: the path and form"
+  "Similar to the `schema-tools.walk/walk` except it keeps track of the `path`
+   through the data structure as it goes, calling `inner` and `outer` with two
+   args: the `path` and the `form`. It also does not preserve any metadata."
   ([inner outer form] (walk-with-path inner outer [] form))
   ([inner outer path form]
    (cond

--- a/core/src/martian/schema_tools.cljc
+++ b/core/src/martian/schema_tools.cljc
@@ -14,7 +14,10 @@
                  :schema (:val-schema schema)}
                 (map? schema)
                 {:path path
-                 :schema schema}))
+                 :schema schema}
+                (vector? schema)
+                {:path (conj path :martian/idx)
+                 :schema (first schema)}))
         (spec/subschemas (s/spec schema))))
 
 (defn key-seqs

--- a/core/src/martian/schema_tools.cljc
+++ b/core/src/martian/schema_tools.cljc
@@ -9,8 +9,7 @@
     (s/explicit-schema-key k)
     k))
 
-(defn default? [schema]
-  (= "schema_tools.impl.Default" (Class/.getName (class schema))))
+(def default-schema? #'sti/default?)
 
 (defn with-paths [path schema]
   (when (satisfies? schema.core/Schema schema)
@@ -20,7 +19,7 @@
                               (instance? EqSchema (:key-schema schema)))
                          (let [key-schema-v (:v (:key-schema schema))
                                val-schema (:val-schema schema)]
-                           (if (default? val-schema)
+                           (if (default-schema? val-schema)
                              [{:path (conj path key-schema-v)
                                :schema val-schema}
                               {:path (conj path key-schema-v :schema)
@@ -33,7 +32,7 @@
                          [{:path path
                            :schema schema}]
                          (vector? schema)
-                         [{:path (conj path :martian/idx)
+                         [{:path (conj path ::idx) ; must be qualified!
                            :schema (first schema)}])))
          (remove nil?))))
 

--- a/core/src/martian/schema_tools.cljc
+++ b/core/src/martian/schema_tools.cljc
@@ -4,8 +4,10 @@
             [schema.spec.core :as spec])
   #?(:clj (:import [schema.core MapEntry EqSchema])))
 
-;; todo
-;; write some tests and lean on schema-tools.core where possible
+(defn unspecify-key [k]
+  (if (s/specific-key? k)
+    (s/explicit-schema-key k)
+    k))
 
 (defn with-paths [path schema]
   (keep (fn [schema]

--- a/core/src/martian/schema_tools.cljc
+++ b/core/src/martian/schema_tools.cljc
@@ -1,5 +1,6 @@
 (ns martian.schema-tools
-  (:require [schema.core :as s #?@(:cljs [:refer [MapEntry EqSchema]])]
+  (:require [flatland.ordered.set :refer [ordered-set]]
+            [schema.core :as s #?@(:cljs [:refer [MapEntry EqSchema]])]
             [schema.spec.core :as spec])
   #?(:clj (:import [schema.core MapEntry EqSchema])))
 
@@ -24,12 +25,16 @@
   "Returns a collection of paths which would address all possible entries (using `get-in`) in data described by the schema"
   [schema]
   (when (map? schema)
-    (loop [paths [[]]
+    (loop [paths (ordered-set [])
            paths-and-schemas (with-paths [] schema)]
       (if-let [{:keys [path schema]} (first paths-and-schemas)]
         (recur (conj paths path) (concat (rest paths-and-schemas)
                                          (with-paths path schema)))
-        paths))))
+        (vec paths)))))
+
+;;
+
+;; TODO: Cover with more tests and lean on the `schema-tools.walk` if possible.
 
 (defn walk-with-path
   "Identical to `clojure.walk/walk` except keeps track of the path through the data structure (as per `get-in`)

--- a/core/src/martian/schema_tools.cljc
+++ b/core/src/martian/schema_tools.cljc
@@ -58,17 +58,27 @@
   ([inner outer form] (walk-with-path inner outer [] form))
   ([inner outer path form]
    (cond
-     (list? form) (outer path (apply list (map (partial inner path) form)))
      (map-entry? form)
-     (outer path #?(:clj (clojure.lang.MapEntry. (inner path (key form)) (inner (conj path (key form)) (val form)))
-                    :cljs (cljs.core/MapEntry. (inner path (key form)) (inner (conj path (key form)) (val form)) nil)))
-     (seq? form) (outer path (doall (map (partial inner path) form)))
-     (record? form) (outer path (reduce (fn [r x] (conj r (inner path x))) form form))
-     (coll? form) (outer path (into (empty form) (map (partial inner path) form)))
+     (outer path [(inner path (key form))
+                  (inner (conj path (key form)) (val form))])
+     (record? form)
+     (outer path (reduce (fn [r x] (conj r (inner path x))) form form))
+     (list? form)
+     (outer path (apply list (map #(inner path %) form)))
+     (seq? form)
+     (outer path (doall (map #(inner path %) form)))
+     (coll? form)
+     (outer path (into (empty form) (map #(inner path %) form)))
      :else (outer path form))))
 
 (defn postwalk-with-path [f path form]
-  (walk-with-path (partial postwalk-with-path f) f path form))
+  (walk-with-path (fn [path form] (postwalk-with-path f path form))
+                  f
+                  path
+                  form))
 
 (defn prewalk-with-path [f path form]
-  (walk-with-path (partial prewalk-with-path f) (fn [_path form] form) path (f path form)))
+  (walk-with-path (fn [path form] (prewalk-with-path f path form))
+                  (fn [_path form] form)
+                  path
+                  (f path form)))

--- a/core/src/martian/schema_tools.cljc
+++ b/core/src/martian/schema_tools.cljc
@@ -50,8 +50,6 @@
 
 ;;
 
-;; TODO: Cover the `walk-with-path` function with some tests.
-
 (defn walk-with-path
   "Similar to the `schema-tools.walk/walk` except it keeps track of the `path`
    through the data structure as it goes, calling `inner` and `outer` with two

--- a/core/src/martian/schema_tools.cljc
+++ b/core/src/martian/schema_tools.cljc
@@ -1,6 +1,5 @@
 (ns martian.schema-tools
-  (:require [flatland.ordered.set :refer [ordered-set]]
-            [schema.core :as s #?@(:cljs [:refer [MapEntry EqSchema]])]
+  (:require [schema.core :as s #?@(:cljs [:refer [MapEntry EqSchema]])]
             [schema-tools.impl :as sti]
             [schema.spec.core :as spec])
   #?(:clj (:import [schema.core MapEntry EqSchema])))
@@ -40,16 +39,16 @@
          (remove nil?))))
 
 (defn key-seqs
-  "Returns a vec of paths (key seqs) which would address all possible entries
-   in a data described by the `schema`."
+  "Returns a coll of paths (key seqs) which would address all possible entries
+   in a data described by the given `schema` as well as the `schema` itself."
   [schema]
   (when (map? schema)
-    (loop [paths (ordered-set [])
+    (loop [paths [[]]
            paths-and-schemas (with-paths [] schema)]
       (if-let [{:keys [path schema]} (first paths-and-schemas)]
         (recur (conj paths path) (concat (rest paths-and-schemas)
                                          (with-paths path schema)))
-        (vec paths)))))
+        (distinct paths)))))
 
 ;;
 

--- a/core/test/martian/parameter_aliases_test.cljc
+++ b/core/test/martian/parameter_aliases_test.cljc
@@ -2,43 +2,56 @@
   (:require [martian.parameter-aliases :refer [parameter-aliases unalias-data alias-schema]]
             [schema-tools.core :as st]
             [schema.core :as s]
-            #?(:clj [clojure.test :refer [deftest testing is]]
+            #?(:clj  [clojure.test :refer [deftest testing is]]
                :cljs [cljs.test :refer-macros [deftest testing is]])))
 
 (deftest parameter-aliases-test
   (testing "produces idiomatic aliases for all keys in a schema"
-    (is (= {[] {:foo-bar :fooBar
-                :bar :BAR
-                :baz :Baz}}
-           (parameter-aliases {:fooBar s/Str
-                               (s/optional-key :BAR) s/Str
-                               :Baz s/Str}))))
+    (testing "map schemas with optional keys"
+      (is (= {[] {:foo-bar :fooBar
+                  :bar :BAR
+                  :baz :Baz}}
+             (parameter-aliases {:fooBar s/Str
+                                 (s/optional-key :BAR) s/Str
+                                 :Baz s/Str}))))
 
-  (testing "works on nested maps and sequences"
-    (is (= {[] {:foo-bar :fooBar
-                :bar :BAR
-                :baz :Baz}
-            [:baz] {:quu :QUU
-                    :quux :Quux}
-            [:baz :quux] {:fizz :Fizz}}
-           (parameter-aliases {:fooBar s/Str
-                               (s/optional-key :BAR) s/Str
-                               :Baz {:QUU s/Str
-                                     :Quux [{:Fizz s/Str}]}}))))
+    (testing "nested map and vector schemas"
+      (is (= {[] {:foo-bar :fooBar
+                  :bar :BAR
+                  :baz :Baz}
+              [:baz] {:quu :QUU
+                      :quux :Quux}
+              [:baz :quux] {:fizz :Fizz}}
+             (parameter-aliases {:fooBar s/Str
+                                 (s/optional-key :BAR) s/Str
+                                 :Baz {:QUU s/Str
+                                       :Quux [{:Fizz s/Str}]}}))))
 
-  (testing "works on nested maps and sequences"
-    (is (= {[] {:foo-bar :fooBar
-                :bar :BAR
-                :baz :Baz}
-            [:baz] {:quu :QUU
-                    :quux :Quux}
-            [:baz :quux] {:fizz :Fizz}}
-           (parameter-aliases {:fooBar s/Str
-                               (s/optional-key :BAR) s/Str
-                               :Baz (st/default {:QUU s/Str
-                                                 :Quux [{:Fizz s/Str}]}
-                                                {:QUU "hi"
-                                                 :Quux []})})))))
+    (testing "deeply nested vector schemas"
+      (is (= {[] {:foo :FOO}
+              [:foo] {:bar :Bar}
+              [:foo :bar] {:bar-doo :barDoo
+                           :bar-dee :barDee}}
+             (parameter-aliases {(s/optional-key :FOO)
+                                 {:Bar [[{:barDoo s/Str
+                                          (s/optional-key :barDee) s/Str}]]}}))))
+
+    (testing "default schemas"
+      (is (= {[] {:foo-bar :fooBar
+                  :bar :BAR
+                  :baz :Baz}
+              [:baz] {:quu :QUU
+                      :quux :Quux}
+              [:baz :quux] {:fizz :Fizz}
+              [:baz :schema] {:quu :QUU, :quux :Quux}
+              [:baz :schema :quux] {:fizz :Fizz}
+              [:baz :value] {:quu :QUU, :quux :Quux}}
+             (parameter-aliases {:fooBar s/Str
+                                 (s/optional-key :BAR) s/Str
+                                 :Baz (st/default {:QUU s/Str
+                                                   :Quux [{:Fizz s/Str}]}
+                                                  {:QUU "hi"
+                                                   :Quux []})}))))))
 
 (deftest unalias-data-test
   (testing "renames idiomatic keys back to original"
@@ -58,9 +71,43 @@
              (unalias-data (parameter-aliases schema) {:foo {:foo-bar "b" :bar [{:baz "c"}]}}))))))
 
 (deftest alias-schema-test
-  (testing "renames the keys in the schema to give an idiomatic input schema"
-    (let [schema {:FOO {:fooBar s/Str
-                        (s/optional-key :Bar) [{:BAZ s/Str}]}}]
+  (testing "renames schema keys into idiomatic keys"
+    (testing "map schemas with optional keys"
+      (is (= {:foo-bar s/Str
+              (s/optional-key :bar) s/Str
+              :baz s/Str}
+             (let [schema {:fooBar s/Str
+                           (s/optional-key :BAR) s/Str
+                           :Baz s/Str}]
+               (alias-schema (parameter-aliases schema) schema)))))
+
+    (testing "nested map and vector schemas"
       (is (= {:foo {:foo-bar s/Str
                     (s/optional-key :bar) [{:baz s/Str}]}}
-             (alias-schema (parameter-aliases schema) schema))))))
+             (let [schema {:FOO {:fooBar s/Str
+                                 (s/optional-key :Bar) [{:BAZ s/Str}]}}]
+               (alias-schema (parameter-aliases schema) schema)))))
+
+    (testing "deeply nested vector schemas"
+      (is (= {(s/optional-key :foo)
+              {:bar [[{:bar-doo s/Str
+                       (s/optional-key :bar-dee) s/Str}]]}}
+             (let [schema {(s/optional-key :FOO)
+                           {:Bar [[{:barDoo s/Str
+                                    (s/optional-key :barDee) s/Str}]]}}]
+               (alias-schema (parameter-aliases schema) schema)))))
+
+    (testing "default schemas"
+      (is (= {:foo-bar s/Str
+              (s/optional-key :bar) s/Str
+              :baz (st/default {:quu s/Str
+                                :quux [{:fizz s/Str}]}
+                               {:quu "hi"
+                                :quux []})}
+             (let [schema {:fooBar s/Str
+                           (s/optional-key :BAR) s/Str
+                           :Baz (st/default {:QUU s/Str
+                                             :Quux [{:Fizz s/Str}]}
+                                            {:QUU "hi"
+                                             :Quux []})}]
+               (alias-schema (parameter-aliases schema) schema)))))))

--- a/core/test/martian/schema_tools_test.cljc
+++ b/core/test/martian/schema_tools_test.cljc
@@ -1,5 +1,5 @@
 (ns martian.schema-tools-test
-  (:require [martian.schema-tools :refer [key-seqs]]
+  (:require [martian.schema-tools :refer [key-seqs prewalk-with-path]]
             [schema.core :as s]
             [schema-tools.core :as st]
             #?(:clj  [clojure.test :refer [deftest testing is]]
@@ -62,3 +62,155 @@
                                        {:QUU "hi"
                                         :Quux []})}))
         "Must contain paths for both the schema and a data described by it")))
+
+(deftest key-seqs-test
+  (testing "map schemas with optional keys"
+    (let [paths+forms (atom [])]
+      (prewalk-with-path (fn [path form]
+                           (swap! paths+forms conj [path form])
+                           form)
+                         []
+                         {:fooBar s/Str
+                          (s/optional-key :BAR) s/Str
+                          :Baz s/Str})
+      (is (= [[[] {:fooBar s/Str, (s/optional-key :BAR) s/Str, :Baz s/Str}]
+              [[] [:fooBar s/Str]]
+              [[] :fooBar]
+              [[:fooBar] s/Str]
+              [[] [(s/optional-key :BAR) s/Str]]
+              [[] (s/optional-key :BAR)]
+              [[] [:k :BAR]]
+              [[] :k]
+              [[:k] :BAR]
+              [[(s/optional-key :BAR)] s/Str]
+              [[] [:Baz s/Str]]
+              [[] :Baz]
+              [[:Baz] s/Str]]
+             @paths+forms))))
+
+  (testing "nested map and vector schemas"
+    (let [paths+forms (atom [])]
+      (prewalk-with-path (fn [path form]
+                           (swap! paths+forms conj [path form])
+                           form)
+                         []
+                         {:fooBar s/Str
+                          (s/optional-key :BAR) s/Str
+                          :Baz {:QUU s/Str
+                                :Quux [{:Fizz s/Str}]}})
+      (is (= [[[] {:fooBar s/Str,
+                   (s/optional-key :BAR) s/Str,
+                   :Baz {:QUU s/Str, :Quux [{:Fizz s/Str}]}}]
+              [[] [:fooBar s/Str]]
+              [[] :fooBar]
+              [[:fooBar] s/Str]
+              [[] [(s/optional-key :BAR) s/Str]]
+              [[] (s/optional-key :BAR)]
+              [[] [:k :BAR]]
+              [[] :k]
+              [[:k] :BAR]
+              [[(s/optional-key :BAR)] s/Str]
+              [[] [:Baz {:QUU s/Str, :Quux [{:Fizz s/Str}]}]]
+              [[] :Baz]
+              [[:Baz] {:QUU s/Str, :Quux [{:Fizz s/Str}]}]
+              [[:Baz] [:QUU s/Str]]
+              [[:Baz] :QUU]
+              [[:Baz :QUU] s/Str]
+              [[:Baz] [:Quux [{:Fizz s/Str}]]]
+              [[:Baz] :Quux]
+              [[:Baz :Quux] [{:Fizz s/Str}]]
+              [[:Baz :Quux] {:Fizz s/Str}]
+              [[:Baz :Quux] [:Fizz s/Str]]
+              [[:Baz :Quux] :Fizz]
+              [[:Baz :Quux :Fizz] s/Str]]
+             @paths+forms))))
+
+  (testing "deeply nested vector schemas"
+    (let [paths+forms (atom [])]
+      (prewalk-with-path (fn [path form]
+                           (swap! paths+forms conj [path form])
+                           form)
+                         []
+                         {(s/optional-key :FOO)
+                          {:Bar [[{:barDoo s/Str
+                                   (s/optional-key :barDee) s/Str}]]}})
+      (is (= [[[] {(s/optional-key :FOO) {:Bar [[{:barDoo s/Str,
+                                                  (s/optional-key :barDee) s/Str}]]}}]
+              [[] [(s/optional-key :FOO)
+                   {:Bar [[{:barDoo s/Str, (s/optional-key :barDee) s/Str}]]}]]
+              [[] (s/optional-key :FOO)]
+              [[] [:k :FOO]]
+              [[] :k]
+              [[:k] :FOO]
+              [[(s/optional-key :FOO)]
+               {:Bar [[{:barDoo s/Str, (s/optional-key :barDee) s/Str}]]}]
+              [[(s/optional-key :FOO)]
+               [:Bar [[{:barDoo s/Str, (s/optional-key :barDee) s/Str}]]]]
+              [[(s/optional-key :FOO)] :Bar]
+              [[(s/optional-key :FOO) :Bar]
+               [[{:barDoo s/Str, (s/optional-key :barDee) s/Str}]]]
+              [[(s/optional-key :FOO) :Bar]
+               [{:barDoo s/Str, (s/optional-key :barDee) s/Str}]]
+              [[(s/optional-key :FOO) :Bar]
+               {:barDoo s/Str, (s/optional-key :barDee) s/Str}]
+              [[(s/optional-key :FOO) :Bar] [:barDoo s/Str]]
+              [[(s/optional-key :FOO) :Bar] :barDoo]
+              [[(s/optional-key :FOO) :Bar :barDoo] s/Str]
+              [[(s/optional-key :FOO) :Bar] [(s/optional-key :barDee) s/Str]]
+              [[(s/optional-key :FOO) :Bar] (s/optional-key :barDee)]
+              [[(s/optional-key :FOO) :Bar] [:k :barDee]]
+              [[(s/optional-key :FOO) :Bar] :k]
+              [[(s/optional-key :FOO) :Bar :k] :barDee]
+              [[(s/optional-key :FOO) :Bar (s/optional-key :barDee)] s/Str]]
+             @paths+forms))))
+
+  (testing "default schemas"
+    (let [paths+forms (atom [])]
+      (prewalk-with-path (fn [path form]
+                           (swap! paths+forms conj [path form])
+                           form)
+                         []
+                         {:fooBar s/Str
+                          (s/optional-key :BAR) s/Str
+                          :Baz (st/default {:QUU s/Str
+                                            :Quux [{:Fizz s/Str}]}
+                                           {:QUU "hi"
+                                            :Quux []})})
+      (is (= [[[] {:fooBar s/Str,
+                   (s/optional-key :BAR) s/Str,
+                   :Baz (st/default {:QUU s/Str, :Quux [{:Fizz s/Str}]} {:QUU "hi", :Quux []})}]
+              [[] [:fooBar s/Str]]
+              [[] :fooBar]
+              [[:fooBar] s/Str]
+              [[] [(s/optional-key :BAR) s/Str]]
+              [[] (s/optional-key :BAR)]
+              [[] [:k :BAR]]
+              [[] :k]
+              [[:k] :BAR]
+              [[(s/optional-key :BAR)] s/Str]
+              [[] [:Baz (st/default {:QUU s/Str, :Quux [{:Fizz s/Str}]} {:QUU "hi", :Quux []})]]
+              [[] :Baz]
+              [[:Baz] (st/default {:QUU s/Str, :Quux [{:Fizz s/Str}]} {:QUU "hi", :Quux []})]
+              [[:Baz] [:schema {:QUU s/Str, :Quux [{:Fizz s/Str}]}]]
+              [[:Baz] :schema]
+              [[:Baz :schema] {:QUU s/Str, :Quux [{:Fizz s/Str}]}]
+              [[:Baz :schema] [:QUU s/Str]]
+              [[:Baz :schema] :QUU]
+              [[:Baz :schema :QUU] s/Str]
+              [[:Baz :schema] [:Quux [{:Fizz s/Str}]]]
+              [[:Baz :schema] :Quux]
+              [[:Baz :schema :Quux] [{:Fizz s/Str}]]
+              [[:Baz :schema :Quux] {:Fizz s/Str}]
+              [[:Baz :schema :Quux] [:Fizz s/Str]]
+              [[:Baz :schema :Quux] :Fizz]
+              [[:Baz :schema :Quux :Fizz] s/Str]
+              [[:Baz] [:value {:QUU "hi", :Quux []}]]
+              [[:Baz] :value]
+              [[:Baz :value] {:QUU "hi", :Quux []}]
+              [[:Baz :value] [:QUU "hi"]]
+              [[:Baz :value] :QUU]
+              [[:Baz :value :QUU] "hi"]
+              [[:Baz :value] [:Quux []]]
+              [[:Baz :value] :Quux]
+              [[:Baz :value :Quux] []]]
+             @paths+forms)))))

--- a/core/test/martian/schema_tools_test.cljc
+++ b/core/test/martian/schema_tools_test.cljc
@@ -1,0 +1,64 @@
+(ns martian.schema-tools-test
+  (:require [martian.schema-tools :refer [key-seqs]]
+            [schema.core :as s]
+            [schema-tools.core :as st]
+            #?(:clj  [clojure.test :refer [deftest testing is]]
+               :cljs [cljs.test :refer-macros [deftest testing is]])))
+
+(deftest key-seqs-test
+  (testing "map schemas with optional keys"
+    (is (= [[]
+            [:fooBar]
+            [:BAR]
+            [:Baz]]
+           (key-seqs {:fooBar s/Str
+                      (s/optional-key :BAR) s/Str
+                      :Baz s/Str}))))
+
+  (testing "nested map and vector schemas"
+    (is (= [[]
+            [:fooBar]
+            [:BAR]
+            [:Baz]
+            [:Baz :QUU]
+            [:Baz :Quux]
+            [:Baz :Quux :Fizz]]
+           (key-seqs {:fooBar s/Str
+                      (s/optional-key :BAR) s/Str
+                      :Baz {:QUU s/Str
+                            :Quux [{:Fizz s/Str}]}}))))
+
+  (testing "deeply nested vector schemas"
+    (is (= [[]
+            [:FOO]
+            [:FOO :Bar]
+            [:FOO :Bar :martian.schema-tools/idx]
+            [:FOO :Bar :martian.schema-tools/idx :barDoo]
+            [:FOO :Bar :martian.schema-tools/idx :barDee]]
+           (key-seqs {(s/optional-key :FOO)
+                      {:Bar [[{:barDoo s/Str
+                               (s/optional-key :barDee) s/Str}]]}}))
+        "Must contain paths with qualified indexes inside the nested vector"))
+
+  (testing "default schemas"
+    (is (= [[]
+            [:fooBar]
+            [:BAR]
+            [:Baz]
+            [:Baz :schema]
+            [:Baz :value]
+            [:Baz :schema :QUU]
+            [:Baz :schema :Quux]
+            [:Baz :value :QUU]
+            [:Baz :value :Quux]
+            [:Baz :QUU]
+            [:Baz :Quux]
+            [:Baz :schema :Quux :Fizz]
+            [:Baz :Quux :Fizz]]
+           (key-seqs {:fooBar s/Str
+                      (s/optional-key :BAR) s/Str
+                      :Baz (st/default {:QUU s/Str
+                                        :Quux [{:Fizz s/Str}]}
+                                       {:QUU "hi"
+                                        :Quux []})}))
+        "Must contain paths for both the schema and a data described by it")))


### PR DESCRIPTION
@oliyh Hi Oliver!

I recently encountered another issue — params with deeply nested vector schemas were not aliased correctly (at all).
It also happened that `st/default` schemas did not get proper treatment as well, resulting in missing aliases in schema.

This PR irons out all these wrinkles and covers all the related logic with unit tests (closing the outstanding ToDo items).

**In Scope:**
- [Account for vector (sub)schemas in with-paths fn](https://github.com/oliyh/martian/commit/79694876fbaf83a82777c547e66661468d556f7e)
- [Enable parameter aliases for st/default schemas](https://github.com/oliyh/martian/commit/09dfdeb1720514a3a13f8839b34a663cd243526b)
- [Avoid duplicate paths in the key-seqs fn result](https://github.com/oliyh/martian/commit/c45fbc192d823028f4828d7044abd264ee7e66b6)
- [Make walk-with-path fn resemble schema-tools.walk/walk](https://github.com/oliyh/martian/commit/04a7686e65559b0d94b711801d5c277f91b6b237)
- [Add more tests for the parameter aliases feature](https://github.com/oliyh/martian/commit/eacac72998a5d1eee26ec19bae2bcc799acedc79)
- [Cover the martian.schema-tool/key-seqs fn with tests](https://github.com/oliyh/martian/commit/6d8d215f2c8c93249f3b8ea7f008574a81fec85f)
- [Cover the martian.schema-tool/prewalk-with-path fn with tests](https://github.com/oliyh/martian/commit/2ecf1fbbff82347319f94e163d88549b0322d5cf)
- and other minor changes

Cheers,
Mark
