### PR TITLE
Handle CLJS relative URLs for specs

### DIFF
--- a/cljs-http-promise/test.cljs.edn
+++ b/cljs-http-promise/test.cljs.edn
@@ -2,5 +2,6 @@
   ;; use an alternative landing page for the tests so that we don't
   ;; launch the application
   :open-url "http://[[server-hostname]]:[[server-port]]/test.html"
-  :launch-js ["/opt/google/chrome/google-chrome" "--headless" "--disable-dev-shm" "--disable-gpu" "--remote-debugging-port=9222" "--repl" :open-url]}
+  :launch-js ["/opt/google/chrome/google-chrome" "--headless" "--disable-dev-shm" "--disable-gpu" "--remote-debugging-port=9222" "--repl" :open-url]
+  :ring-handler martian.static-handler/handler}
 {:main martian.test-runner}

--- a/cljs-http-promise/test/martian/cljs_http_promise_test.cljs
+++ b/cljs-http-promise/test/martian/cljs_http_promise_test.cljs
@@ -12,6 +12,9 @@
 (def swagger-url "http://localhost:8888/swagger.json")
 (def openapi-url "http://localhost:8888/openapi.json")
 (def openapi-test-url "http://localhost:8888/openapi-test.json")
+(def openapi-test-relative-url-with-servers "/openapi-test.json")
+(def openapi-test-relative-url-no-servers "/openapi-relative-url-no-servers-test.json")
+(def openapi-test-relative-url-no-servers-leading-path "/api/openapi-relative-url-no-servers-test.json")
 (def openapi-coercions-url "http://localhost:8888/openapi-coercions.json")
 
 (defn report-error-and-throw [err]
@@ -62,6 +65,30 @@
         (prom/then (fn [m]
                      (is (= "http://localhost:8888/v3.1"
                             (:api-root m)) "check relative server url via opts")))
+        (prom/catch report-error-and-throw))
+
+    (-> (martian-http/bootstrap-openapi openapi-test-relative-url-with-servers)
+        (prom/then (fn [m]
+                     (is (= "https://sandbox.example.com"
+                            (:api-root m)) "check relative spec url with servers")))
+        (prom/catch report-error-and-throw))
+
+    (-> (martian-http/bootstrap-openapi openapi-test-relative-url-with-servers {:server-url "https://example.com"})
+        (prom/then (fn [m]
+                     (is (= "https://example.com"
+                            (:api-root m)) "check relative spec url with server-url")))
+        (prom/catch report-error-and-throw))
+
+    (-> (martian-http/bootstrap-openapi openapi-test-relative-url-no-servers)
+        (prom/then (fn [m]
+                     (is (= ""
+                            (:api-root m)) "check relative spec url without servers")))
+        (prom/catch report-error-and-throw))
+
+    (-> (martian-http/bootstrap-openapi openapi-test-relative-url-no-servers-leading-path)
+        (prom/then (fn [m]
+                     (is (= "/api"
+                            (:api-root m)) "check relative spec url without servers and leading path")))
         (prom/catch report-error-and-throw))
 
     (-> (prom/let [m (martian-http/bootstrap-openapi openapi-url)]

--- a/cljs-http/test.cljs.edn
+++ b/cljs-http/test.cljs.edn
@@ -2,5 +2,6 @@
   ;; use an alternative landing page for the tests so that we don't
   ;; launch the application
   :open-url "http://[[server-hostname]]:[[server-port]]/test.html"
-  :launch-js ["/opt/google/chrome/google-chrome" "--headless" "--disable-dev-shm" "--disable-gpu" "--remote-debugging-port=9222" "--repl" :open-url]}
+  :launch-js ["/opt/google/chrome/google-chrome" "--headless" "--disable-dev-shm" "--disable-gpu" "--remote-debugging-port=9222" "--repl" :open-url]
+  :ring-handler martian.static-handler/handler}
 {:main martian.test-runner}

--- a/cljs-http/test/martian/cljs_http_test.cljs
+++ b/cljs-http/test/martian/cljs_http_test.cljs
@@ -59,11 +59,11 @@
                  (:api-root (<! (martian-http/bootstrap-openapi openapi-test-relative-url-with-servers {:server-url "https://example.com"}))))
               "check relative spec url with server-url")
 
-          (is (= "" #_"/"
+          (is (= ""
                  (:api-root (<! (martian-http/bootstrap-openapi openapi-test-relative-url-no-servers))))
               "check relative spec url without servers")
 
-          (is (= "" #_"/api"
+          (is (= "/api"
                  (:api-root (<! (martian-http/bootstrap-openapi openapi-test-relative-url-no-servers-leading-path))))
               "check relative spec url without servers and leading path")
 

--- a/cljs-http/test/martian/cljs_http_test.cljs
+++ b/cljs-http/test/martian/cljs_http_test.cljs
@@ -13,6 +13,9 @@
 (def swagger-url "http://localhost:8888/swagger.json")
 (def openapi-url "http://localhost:8888/openapi.json")
 (def openapi-test-url "http://localhost:8888/openapi-test.json")
+(def openapi-test-relative-url-with-servers "/openapi-test.json")
+(def openapi-test-relative-url-no-servers "/openapi-relative-url-no-servers-test.json")
+(def openapi-test-relative-url-no-servers-leading-path "/api/openapi-relative-url-no-servers-test.json")
 (def openapi-coercions-url "http://localhost:8888/openapi-coercions.json")
 
 (deftest swagger-http-test
@@ -47,6 +50,22 @@
           (is (= "http://localhost:8888/v3.1"
                  (:api-root (<! (martian-http/bootstrap-openapi openapi-test-url {:server-url "/v3.1"}))))
               "check relative server url via opts")
+
+          (is (= "https://sandbox.example.com"
+                 (:api-root (<! (martian-http/bootstrap-openapi openapi-test-relative-url-with-servers))))
+              "check relative spec url with servers")
+
+          (is (= "https://example.com"
+                 (:api-root (<! (martian-http/bootstrap-openapi openapi-test-relative-url-with-servers {:server-url "https://example.com"}))))
+              "check relative spec url with server-url")
+
+          (is (= "" #_"/"
+                 (:api-root (<! (martian-http/bootstrap-openapi openapi-test-relative-url-no-servers))))
+              "check relative spec url without servers")
+
+          (is (= "" #_"/api"
+                 (:api-root (<! (martian-http/bootstrap-openapi openapi-test-relative-url-no-servers-leading-path))))
+              "check relative spec url without servers and leading path")
 
           (is (= "http://localhost:8888/openapi/v3"
                  (:api-root m)))

--- a/core/src/martian/openapi.cljc
+++ b/core/src/martian/openapi.cljc
@@ -12,18 +12,49 @@
 (defn openapi-schema? [json]
   (boolean (some #(get json %) [:openapi "openapi"])))
 
-(defn base-url [url server-url json]
+(defn base-url
+  "Returns the API root URL derived from the spec URL, an optional
+  server override, and the parsed JSON spec.
+
+  Resolution order for OpenAPI (3.x) specs:
+
+  1. If `server-url` is provided and non-blank, it is used as-is when
+     absolute (e.g. \"https://example.com\"), or resolved against `url`
+     when relative (e.g. \"/v3\" → \"http://host/v3\").
+
+  2. Otherwise, `servers[0].url` from the spec is used, applying the
+     same absolute-vs-relative logic.
+
+  3. If neither is present (no `:servers` key in the spec), the base is
+     derived from the directory of `url` via RFC 3986 resolution:
+     - absolute `url`  → origin only, e.g. \"http://localhost:8888\"
+     - relative `url`  → parent path, e.g. \"/api/spec.json\" → \"/api\"
+     - top-level relative `url` (e.g. \"/spec.json\") → \"\" (empty string),
+       which is correct because OpenAPI paths begin with \"/\", so
+       api-root + path remains a valid relative URL.
+
+  For Swagger (2.x) specs, the base is always reconstructed as
+  scheme://host[:port] + basePath from the parsed `url`.
+
+  The return value never has a trailing slash."
+  [url server-url json]
   (let [first-server (get-in json [:servers 0 :url] "")
         {:keys [scheme host port]} (uri/uri url)
         api-root (or server-url first-server)]
-    (if (and (openapi-schema? json) (not (str/starts-with? api-root "/")))
-      api-root
+    (if (openapi-schema? json)
+      (if (str/blank? api-root)
+        ;; No servers declared: derive base from "directory" of the fetch URL
+        (str/replace (str (uri/join url ".")) #"/$" "")
+        (if (str/starts-with? api-root "/")
+          ;; Relative server path (e.g. "/v3"): resolve against the fetch URL
+          (str (uri/join url api-root))
+          ;; Absolute api-root: return verbatim
+          api-root))
+      ;; Swagger / non-OpenAPI: reconstruct origin + basePath
       (str scheme "://"
            host
            (when (not (str/blank? port)) (str ":" port))
-           (if (openapi-schema? json)
-             api-root
-             (get json :basePath ""))))))
+           (get json :basePath "")))))
 
 (defn- wrap-nullable [{:keys [nullable]} schema]
   (if nullable

--- a/core/src/martian/openapi.cljc
+++ b/core/src/martian/openapi.cljc
@@ -43,10 +43,10 @@
         api-root (or server-url first-server)]
     (if (openapi-schema? json)
       (if (str/blank? api-root)
-        ;; No servers declared: derive base from "directory" of the fetch URL
+        ;; No servers declared: derive base from "directory" of the spec URL
         (str/replace (str (uri/join url ".")) #"/$" "")
         (if (str/starts-with? api-root "/")
-          ;; Relative server path (e.g. "/v3"): resolve against the fetch URL
+          ;; Relative server path (e.g. "/v3"): resolve against the spec URL
           (str (uri/join url api-root))
           ;; Absolute api-root: return verbatim
           api-root))

--- a/core/test/martian/openapi_test.cljc
+++ b/core/test/martian/openapi_test.cljc
@@ -1,6 +1,6 @@
 (ns martian.openapi-test
   (:require [clojure.test :refer [deftest is testing]]
-            [martian.openapi :refer [openapi->handlers]]
+            [martian.openapi :refer [base-url openapi->handlers]]
             [martian.test-helpers #?@(:clj  [:refer [json-resource yaml-resource]]
                                       :cljs [:refer-macros [json-resource yaml-resource]])]
             [schema-tools.core :as st]
@@ -262,3 +262,53 @@
           (is (thrown? #?(:clj Throwable
                           :cljs :default)
                        (s/validate status-schema invalid-status))))))))
+
+(deftest base-url-test
+  (let [openapi-abs-server {:openapi "3.1.0" :servers [{:url "https://sandbox.example.com"}]}
+        openapi-rel-server {:openapi "3.1.0" :servers [{:url "/v3"}]}
+        openapi-no-servers {:openapi "3.1.0"}
+        swagger-json       {:swagger "2.0"   :basePath "/v2"}]
+
+    (testing "OpenAPI — absolute servers[0].url wins regardless of spec URL"
+      (is (= "https://sandbox.example.com"
+             (base-url "http://localhost:8888/spec.json" nil openapi-abs-server))
+          "absolute spec URL")
+      (is (= "https://sandbox.example.com"
+             (base-url "/spec.json" nil openapi-abs-server))
+          "relative spec URL"))
+
+    (testing "OpenAPI — explicit server-url overrides everything"
+      (is (= "https://example.com"
+             (base-url "http://localhost:8888/spec.json" "https://example.com" openapi-abs-server))
+          "absolute server-url, absolute spec URL")
+      (is (= "https://example.com"
+             (base-url "/spec.json" "https://example.com" openapi-abs-server))
+          "absolute server-url, relative spec URL"))
+
+    (testing "OpenAPI — relative server-url resolved against absolute spec URL"
+      (is (= "http://localhost:8888/v3.1"
+             (base-url "http://localhost:8888/spec.json" "/v3.1" openapi-abs-server))
+          "explicit relative server-url"))
+
+    (testing "OpenAPI — relative servers[0].url resolved against absolute spec URL"
+      (is (= "http://localhost:8888/v3"
+             (base-url "http://localhost:8888/spec.json" nil openapi-rel-server))
+          "relative servers entry, absolute spec URL"))
+
+    (testing "OpenAPI — no servers, absolute spec URL: base is origin, no trailing slash"
+      (is (= "" #_ "http://localhost:8888"
+             (base-url "http://localhost:8888/spec.json" nil openapi-no-servers))))
+
+    (testing "OpenAPI — no servers, relative spec URL at root: base is empty string"
+      (is (= ""
+             (base-url "/spec.json" nil openapi-no-servers))
+          "root-level spec → empty string (paths start with /, so api-root + path stays valid)"))
+
+    (testing "OpenAPI — no servers, relative spec URL with path prefix: base is parent path"
+      (is (= "" #_ "/api"
+             (base-url "/api/spec.json" nil openapi-no-servers))
+          "spec in /api/ → /api, no trailing slash"))
+
+    (testing "Swagger — absolute spec URL: origin + basePath"
+      (is (= "http://localhost:8888/v2"
+             (base-url "http://localhost:8888/swagger.json" nil swagger-json))))))

--- a/core/test/martian/openapi_test.cljc
+++ b/core/test/martian/openapi_test.cljc
@@ -296,7 +296,7 @@
           "relative servers entry, absolute spec URL"))
 
     (testing "OpenAPI — no servers, absolute spec URL: base is origin, no trailing slash"
-      (is (= "" #_ "http://localhost:8888"
+      (is (= "http://localhost:8888"
              (base-url "http://localhost:8888/spec.json" nil openapi-no-servers))))
 
     (testing "OpenAPI — no servers, relative spec URL at root: base is empty string"
@@ -305,7 +305,7 @@
           "root-level spec → empty string (paths start with /, so api-root + path stays valid)"))
 
     (testing "OpenAPI — no servers, relative spec URL with path prefix: base is parent path"
-      (is (= "" #_ "/api"
+      (is (= "/api"
              (base-url "/api/spec.json" nil openapi-no-servers))
           "spec in /api/ → /api, no trailing slash"))
 

--- a/test-common/martian/static_handler.clj
+++ b/test-common/martian/static_handler.clj
@@ -1,0 +1,13 @@
+(ns martian.static-handler
+  (:require [ring.middleware.resource :refer [wrap-resource]]))
+
+;; Serves classpath resources under the "public/" prefix.
+;; Used by figwheel's built-in Jetty server so that relative-URL XHRs
+;; from the browser (e.g. GET /openapi-test.json) resolve correctly
+;; against figwheel's origin rather than the Pedestal API stub (:8888).
+;; The "public" directory is on the classpath via ../test-common in
+;; each module's dev :resource-paths.
+(def handler
+  (wrap-resource
+    (fn [_req] {:status 404 :headers {} :body "Not found"})
+    "public"))

--- a/test-common/public/api/openapi-relative-url-no-servers-test.json
+++ b/test-common/public/api/openapi-relative-url-no-servers-test.json
@@ -1,0 +1,26 @@
+{"openapi": "3.1.0",
+ "info":
+ {"version": "1.2.3",
+  "title": "Repro",
+  "description": "A OAS 3.1.0 definition for testing relative URLs."},
+ "paths":
+ {"/items":
+  {"get":
+   {"summary": "Gets a list of items.",
+    "description": "Filler",
+    "operationId": "list-items",
+    "parameters":
+    [{"in": "query",
+      "name": "ClientId",
+      "description": "Client identifier",
+      "schema": {"type": "string"},
+      "required": false}],
+    "responses":
+    {"200":
+     {"description": "Success.",
+      "content":
+      {"application/json":
+       {"schema":
+        {"type": "array",
+         "maxItems": 5000,
+         "items": {"type": "string"}}}}}}}}}}

--- a/test-common/public/openapi-relative-url-no-servers-test.json
+++ b/test-common/public/openapi-relative-url-no-servers-test.json
@@ -1,0 +1,26 @@
+{"openapi": "3.1.0",
+ "info":
+ {"version": "1.2.3",
+  "title": "Repro",
+  "description": "A OAS 3.1.0 definition for testing relative URLs."},
+ "paths":
+ {"/items":
+  {"get":
+   {"summary": "Gets a list of items.",
+    "description": "Filler",
+    "operationId": "list-items",
+    "parameters":
+    [{"in": "query",
+      "name": "ClientId",
+      "description": "Client identifier",
+      "schema": {"type": "string"},
+      "required": false}],
+    "responses":
+    {"200":
+     {"description": "Success.",
+      "content":
+      {"application/json":
+       {"schema":
+        {"type": "array",
+         "maxItems": 5000,
+         "items": {"type": "string"}}}}}}}}}}


### PR DESCRIPTION
When `bootstrap-openapi` is called with a relative URL in a CLJS environment, and the spec does not contain a `:servers` key, and no `:server-url` option is specified, then `bootstrap-openapi` should return a martian with an `:api-root` which is also a relative URL with the last path segment removed.

I believe this PR addresses #168 and #216.