### PR TITLE
feat(schema-tools): fix cljs macro

### DIFF
--- a/core/src/martian/schema_tools.cljc
+++ b/core/src/martian/schema_tools.cljc
@@ -1,7 +1,8 @@
 (ns martian.schema-tools
   (:require [camel-snake-kebab.core :refer [->kebab-case]]
             [schema.core :as s]
-            [schema-tools.impl]))
+            [schema-tools.impl])
+  #?(:cljs (:require-macros [martian.schema-tools])))
 
 (defn explicit-key [k]
   (if (s/specific-key? k) (s/explicit-schema-key k) k))
@@ -62,14 +63,15 @@
    along a single path."
   3)
 
-(defmacro with-recursion-guard [rec-target form]
-  `(when ~rec-target
-     (let [n# (get @*seen-recursion* ~rec-target 0)]
-       (when (< n# *max-recursions-per-target*)
-         (vswap! *seen-recursion* update ~rec-target (fnil inc 0))
-         (let [res# ~form]
-           (vswap! *seen-recursion* update ~rec-target #(max 0 (dec %)))
-           res#)))))
+#(:clj
+  (defmacro with-recursion-guard [rec-target form]
+    `(when ~rec-target
+       (let [n# (get @*seen-recursion* ~rec-target 0)]
+         (when (< n# *max-recursions-per-target*)
+           (vswap! *seen-recursion* update ~rec-target (fnil inc 0))
+           (let [res# ~form]
+             (vswap! *seen-recursion* update ~rec-target (fn [x] (max 0 (dec x))))
+             res#))))))
 
 (defprotocol PathAliases
   "Internal traversal API used to locate alias maps inside Prismatic schemas."


### PR DESCRIPTION
## Description

Fix the following warning in Clojurescript:

```
------ WARNING #1 - :undeclared-var --------------------------------------------
 Resource: martian/schema_tools.cljc:207:10
--------------------------------------------------------------------------------
 204 |     (let [target (:derefable schema)]
 205 |       (concat*
 206 |         (when include-self? (list path))
 207 |         (with-recursion-guard
----------------^---------------------------------------------------------------
 Use of undeclared Var martian.schema-tools/with-recursion-guard
--------------------------------------------------------------------------------
 208 |           target
 209 |           (let [inner-schema @target]
 210 |             (concat
 211 |               (-paths inner-schema (conj path :derefable) true)
--------------------------------------------------------------------------------
```